### PR TITLE
Fixed prometheus query body parameter

### DIFF
--- a/src/clients/prometheus.js
+++ b/src/clients/prometheus.js
@@ -21,7 +21,7 @@ class Read {
     return this.service.request('/api/v1/query', {
       method: 'POST',
       headers: this.headers(),
-      body: { query }
+      body: new URLSearchParams({ query })
     }).catch(error => {
       if (error instanceof GigapipeError) {
         throw error;


### PR DESCRIPTION
Inside query function for prometheus I wrapped body argument value into "URLSearchParams", because fetch does not support plain object as body argument for the request