### PR TITLE
v1.1.0: per-call abort/timeout/retry, pluggable auth, LokiReader, Tempo alignment, .d.ts

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,34 @@
+# Paths agents should not load into context.
+# Mirrors .gitignore plus secrets-shaped paths.
+# Recognized by: Cursor (.aiexclude), Gemini Code Assist, generic LLM tooling.
+
+# Dependencies — not source
+node_modules/
+
+# Lock files — generated, large, no semantic content for agents
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Editor / IDE state
+.vscode/
+.idea/
+
+# Build / coverage / cache (none today, prophylactic)
+dist/
+build/
+coverage/
+.cache/
+
+# OS noise
+.DS_Store
+Thumbs.db
+
+# Secrets-shaped — defense in depth, even though .gitignore should catch these
+.env
+.env.*
+*.pem
+*.key
+*.crt
+secrets.json
+credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
+dist/
 .vscode
+docs\refreance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,208 @@
+# AGENTS.md
+
+Guidance for any coding agent (Claude Code, Codex, Cursor, Copilot, Aider, etc.) working in this repository.
+
+This file is the **single source of truth** for agents. `CLAUDE.md` and any vendor-specific config files point here.
+
+---
+
+## 1. Project overview
+
+`qryn-client` is the official Node.js client for [qryn](https://qryn.dev), a polyglot observability backend that speaks Loki (logs), Prometheus remote-write + query (metrics), and Tempo (traces).
+
+The library is a thin wrapper around `fetch` that:
+- Buffers logs, metrics, and traces into model objects (`Stream`, `Metric`).
+- Pushes them to qryn endpoints with optimistic confirm/undo semantics.
+- Optionally batches via a `Collector` that flushes on size or timeout.
+- Encodes Prometheus remote-write payloads with protobuf + snappy.
+
+Pure CommonJS, Node ≥ 18 (uses native `fetch` and `AbortSignal.timeout`).
+
+---
+
+## 2. Repository layout
+
+```
+qryn-client/
+├─ src/
+│  ├─ index.js                  # QrynClient (entry); composes Loki/Prom/Tempo + Http
+│  ├─ clients/
+│  │  ├─ loki.js                # Loki push (logs)
+│  │  ├─ prometheus.js          # Prometheus push (remote-write) + Read class (PromQL)
+│  │  └─ tempo.js               # Tempo search + trace fetch
+│  ├─ models/
+│  │  ├─ index.js               # exports Metric, Stream
+│  │  ├─ stream.js              # Stream model — log entries with confirm/undo lifecycle
+│  │  └─ metric.js              # Metric model — samples with confirm/undo lifecycle
+│  ├─ services/
+│  │  ├─ http.js                # fetch wrapper, basic auth, timeouts, error normalization
+│  │  ├─ protobuff.js           # protobufjs + snappy encoder for remote-write
+│  │  └─ remote.proto           # vendored Prometheus remote-write schema (DO NOT edit)
+│  ├─ types/
+│  │  ├─ index.js               # exports QrynError, QrynResponse, NetworkError, ValidationError
+│  │  ├─ qrynError.js           # error class with statusCode + cause + path
+│  │  └─ qrynResponse.js        # response wrapper with isSuccess, headers helpers
+│  └─ utils/
+│     └─ collector.js           # batches Streams/Metrics, LRU cache, retries, EventEmitter
+├─ example/                     # smoke scripts driven by env vars (not tests)
+├─ docs/
+│  ├─ architecture.md           # one-page mental model
+│  ├─ AUDIT.md                  # snapshot audit (gaps, fixes, follow-ups)
+│  └─ todo.md                   # post-fix backlog
+├─ .github/workflows/npm_release.yml   # CI publishes on GitHub release
+├─ AGENTS.md                    # this file
+├─ CLAUDE.md                    # pointer to this file
+└─ README.md                    # user-facing API docs
+```
+
+---
+
+## 3. Architecture (TL;DR)
+
+`QrynClient` composes three sub-clients (`Loki`, `Prometheus`, `Tempo`), each holding a reference to a single shared `Http` service. All HTTP traffic flows through `Http.request()`, which handles base URL resolution, basic auth, timeout (`AbortSignal.timeout`), and error normalization (everything throws `QrynError`).
+
+`Stream` and `Metric` are buffer-and-flush models. The `Collector` adds bulk batching: it deduplicates Streams/Metrics by a generated `key`, keeps them in an `LRUCache`, and flushes when total entries+samples cross `maxBulkSize` or `maxTimeout` elapses.
+
+For the deeper view (data flow, lifecycle invariants, batching state machine), see [`docs/architecture.md`](docs/architecture.md).
+
+---
+
+## 4. Public API surface
+
+Exported from `src/index.js`:
+
+| Symbol | Purpose |
+|---|---|
+| `QrynClient` | Entry point. `new QrynClient({ baseUrl, auth, timeout, headers })` |
+| `Stream` | Log stream model. Usually obtained via `client.createStream(labels)`. |
+| `Metric` | Metric model. Usually obtained via `client.createMetric({ name, labels })`. |
+| `Collector` | Batching wrapper. Usually obtained via `client.createCollector(opts)`. |
+
+Both direct instantiation (`new Stream(...)`) and factory methods (`client.createStream(...)`) are supported. **Prefer the factory methods**; they're the documented entry path and are easier to wire to a `Collector` later.
+
+---
+
+## 5. Lifecycle invariants (CRITICAL — read before adding clients)
+
+`Stream` and `Metric` implement an optimistic push pattern. Any client that consumes them MUST honor the contract:
+
+```
+addEntry/addSample  ──▶  buffers in `entries` / `samples`
+        │
+        ▼
+collect()           ──▶  snapshots buffer, returns serialized payload, CLEARS buffer
+        │
+        ├── (server 2xx) ──▶ confirm()  — discards the snapshot
+        └── (error)      ──▶ undo()     — restores snapshot to head of buffer for retry
+```
+
+**If you add a new client that pushes Streams or Metrics, you must call `confirm()` on success and `undo()` on failure.** Skipping `undo()` silently drops data. Skipping `confirm()` causes data to be retried indefinitely on the next push.
+
+The existing Loki and Prometheus clients are the reference implementations. Mirror their try/catch shape exactly.
+
+---
+
+## 6. Build / run / test
+
+```bash
+npm install              # installs deps; no build step
+node example/index.js    # smoke push (needs QYRN_WRITE_URL, QYRN_LOGIN, QRYN_PASSWORD env vars)
+node example/collector.js
+node example/read.js     # needs QYRN_READ_URL, QYRN_ORG_ID
+```
+
+**There is no test suite yet.** This is tracked in [`docs/todo.md`](docs/todo.md). Until one exists, validate changes by:
+
+1. Requiring the entry and instantiating: `node -e "require('./src')"`.
+2. Running the relevant `example/*.js` against a live qryn (or a local qryn container).
+
+---
+
+## 7. Code style
+
+- **Module system:** CommonJS only (`require` / `module.exports`). Do not introduce ESM.
+- **Language:** Plain JavaScript. No TypeScript. Public methods are JSDoc-typed; honor that pattern when adding methods.
+- **Privacy:** Use `#privateField` for genuinely private state (see `Stream`, `Metric`, `Http`). Do not introduce `_underscorePrefix` conventions.
+- **Errors:** Always throw `QrynError` (or a subclass) at module boundaries. Never `console.error` and swallow.
+- **No linter / formatter is configured.** Don't auto-format files you didn't touch. Match surrounding indentation (2 spaces) and quote style (single quotes).
+- **Dependencies:** Resist adding them. Current set: `lru-cache`, `protobufjs`, `snappy`. Anything else needs justification.
+
+---
+
+## 8. Commit & PR conventions
+
+Inferred from `git log`:
+
+- Subjects are short, lowercase, imperative-ish, **not** Conventional Commits. Examples: `tempo client added to request the traces using search method`, `error handling`, `Updated collector and error handling`.
+- PRs from forks are squash-merged with a `Merge pull request #N from user/branch` commit.
+- No CHANGELOG file is maintained; release notes live on GitHub Releases.
+
+Match this style. If you want to introduce Conventional Commits, that's a project-wide decision — open an issue first.
+
+---
+
+## 9. Release process
+
+Releases are CI-driven via [`.github/workflows/npm_release.yml`](.github/workflows/npm_release.yml):
+
+1. Bump `version` in `package.json` and merge to `main`.
+2. Create a GitHub Release pointing at the new tag.
+3. The workflow runs `npm publish --access public` using `secrets.NPM_TOKEN`.
+
+**Do not manually `npm publish` from a local machine.** Do not edit `.github/workflows/*` without explicit instruction.
+
+---
+
+## 10. Known pitfalls — DO NOT "fix" blindly
+
+These look like bugs at first glance. Some have already been fixed in the audit pass; others are subtle invariants. Read [`docs/AUDIT.md`](docs/AUDIT.md) before changing any of these lines.
+
+- **`Http.request()` content-type handling.** The body is parsed based on the **response** content-type (after the audit fix), not the request content-type. Re-introducing a request-content-type gate will silently empty most response bodies.
+- **`fpLimit` / `ttlDays` headers.** These map to `X-FP-Limit` and `X-Ttl-Days` respectively (after the audit fix). Earlier versions had them swapped — consumers may have been relying on the swap. Don't re-swap them.
+- **`Stream.collect()` clears the buffer.** This is intentional for the confirm/undo pattern. Do not "fix" it to leave entries in place.
+- **`Loki.push` validator pushes inside the `every()` callback.** The pattern is intentional (single-pass collect + validate). It's ugly but correct after re-reading. If you refactor it, preserve the "skip empty streams, accept non-Stream as failure" behavior.
+- **`Tempo.search()` now throws `QrynError` (after audit fix).** Earlier versions logged and returned `undefined`; the documented `.catch()` failover pattern relies on the throw.
+
+---
+
+## 11. Agent boundaries
+
+Files an autonomous agent should **not** modify without explicit user instruction:
+
+| Path | Why |
+|---|---|
+| `src/services/remote.proto` | Vendored upstream Prometheus remote-write schema. Update only when upstream changes. |
+| `.github/workflows/*` | Release infrastructure. Mistakes affect npm publish. |
+| `package.json` `version` field | Owned by the release process; bump only in a dedicated release commit. |
+| `package-lock.json` | Not tracked in this repo (intentionally — see `.gitignore`). Don't add it. |
+| `example/*` | Smoke scripts wired to env vars. Add new examples; don't restructure existing ones. |
+
+Files agents are free to edit:
+
+- Anything under `src/` (subject to `Section 5` lifecycle rules and the `Section 10` pitfalls).
+- `README.md`, `AGENTS.md`, `CLAUDE.md`, anything under `docs/`.
+- `package.json` `dependencies` / `description` / `keywords` (not `version`).
+
+---
+
+## 12. Recipe — adding a new client
+
+To add a new sub-client (e.g., a future Pyroscope/profiles client):
+
+1. **Create the file:** `src/clients/<name>.js`. Class takes `service` (Http) in the constructor.
+2. **Mirror the error pattern:** wrap each request in `.catch()` that re-throws `QrynError` with a contextual message and `error.statusCode`. Look at `src/clients/loki.js` for the canonical shape.
+3. **Honor `orgId`:** add a `headers(options)` method that conditionally sets `X-Scope-OrgID`. Match Loki/Prometheus.
+4. **Wire into `QrynClient`:** require it in `src/index.js` and add `this.<name> = new <Name>Client(http)` in the constructor.
+5. **JSDoc every public method.** No exceptions — this library has no `.d.ts`, so JSDoc is the contract.
+6. **Document in `README.md`:** add a `### <Name>` section under "Usage" with a working example, and an entry in the API Reference.
+7. **Add a smoke example:** `example/<name>.js` driven by env vars.
+
+---
+
+## 13. References
+
+- [`README.md`](README.md) — user-facing API docs.
+- [`docs/architecture.md`](docs/architecture.md) — data-flow + lifecycle deep-dive.
+- [`docs/AUDIT.md`](docs/AUDIT.md) — snapshot audit (what was found, what got fixed, what's left).
+- [`docs/todo.md`](docs/todo.md) — post-fix backlog.
+- [qryn project](https://qryn.dev) — backend this client targets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](AGENTS.md). It is the single source of truth for any coding agent (Claude Code, Codex, Cursor, Copilot, Aider, etc.) working in this repository.
+
+No Claude-specific deviations apply at this time. If you find guidance that should diverge for Claude only, propose it as an addition here rather than forking AGENTS.md.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,154 @@ You can install qryn-client using npm:
 npm install qryn-client
 ```
 
+## Migration to 1.1.0
+
+### Auth shapes
+
+Version 1.1.0 introduces a discriminated-union auth config. The old `{ username, password }` shape still works but emits a `DeprecationWarning` (code `QRYN_AUTH_LEGACY`) once per process and will be removed in 2.0.0.
+
+```js
+const { QrynClient } = require('qryn-client');
+
+// basic (new preferred shape)
+const client = new QrynClient({
+  baseUrl: 'https://qryn.example.com',
+  auth: { type: 'basic', username: 'user', password: 'pass' }
+});
+
+// bearer — static string or async thunk (re-invoked each request)
+const client = new QrynClient({
+  baseUrl: 'https://qryn.example.com',
+  auth: { type: 'bearer', token: () => fetchToken() }
+});
+
+// custom — header map or async thunk
+const client = new QrynClient({
+  baseUrl: 'https://qryn.example.com',
+  auth: { type: 'custom', headers: { 'X-Api-Key': 'my-key' } }
+});
+
+// legacy — still accepted, emits DeprecationWarning QRYN_AUTH_LEGACY
+const client = new QrynClient({
+  baseUrl: 'https://qryn.example.com',
+  auth: { username: 'user', password: 'pass' }
+});
+```
+
+### New constructor options
+
+```js
+const client = new QrynClient({
+  baseUrl: 'https://qryn.example.com',
+  auth: { type: 'basic', username: 'user', password: 'pass' },
+  timeout: 60000,      // default is now 60 000 ms (was 5 000 ms in 1.0.x)
+  retry: {             // default: { attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 }
+    attempts: 5,
+    baseDelayMs: 500,
+    maxDelayMs: 10000
+  },
+  defaultOrgId: 'tenant-a'  // sent as X-Scope-OrgID on every request
+});
+```
+
+**Default timeout change:** the client-level `timeout` default is now `60_000` ms (was `5_000` ms). If your code relied on the 5 s default, pass `timeout: 5000` explicitly.
+
+### Retry policy
+
+Requests are automatically retried on transient failures. The built-in defaults:
+
+| Setting | Default |
+|---|---|
+| `attempts` | `3` |
+| `baseDelayMs` | `200` |
+| `maxDelayMs` | `5000` |
+
+Retries fire on network errors (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`) and HTTP `408 / 429 / 502 / 503 / 504`. On HTTP 429 the `Retry-After` response header is honored. Retries never fire after a caller abort.
+
+Pass `retry` in the constructor to set a process-wide policy, or per-call via the `opts` argument to override for a single request.
+
+### Per-call opts
+
+Every read method (Loki reader, Prom reader, Tempo), `loki.push`, and `prom.push` accept an `opts` argument:
+
+```js
+const opts = {
+  signal: controller.signal,  // AbortSignal — cancels the request immediately
+  timeoutMs: 5000,             // per-call timeout; overrides constructor timeout
+  retry: { attempts: 1 },     // per-call retry policy; overrides constructor retry
+  orgId: 'tenant-b'           // per-call X-Scope-OrgID; overrides defaultOrgId
+};
+
+await client.loki.push([stream], opts);
+await reader.query('{job="x"}', new Date(), opts);
+await client.tempo.search({ q: '{}' }, opts);
+```
+
+### Abort and timeout errors
+
+```js
+const { QrynAbortedError, QrynTimeoutError } = require('qryn-client');
+
+try {
+  await client.loki.push([stream], { timeoutMs: 2000 });
+} catch (e) {
+  if (e instanceof QrynTimeoutError) {
+    // per-request timeout fired; e.durationMs tells you how long it ran
+    console.error('timed out after', e.durationMs, 'ms');
+  }
+}
+
+const controller = new AbortController();
+controller.abort();
+try {
+  await client.loki.push([stream], { signal: controller.signal });
+} catch (e) {
+  if (e instanceof QrynAbortedError) {
+    // caller cancelled; safe to ignore or log
+  }
+}
+```
+
+For the underlying HTTP and auth architecture, see [`docs/architecture.md`](docs/architecture.md).
+
+### Loki reader
+
+`client.loki.createReader(options?)` returns a `LokiReader` with the full LogQL read surface.
+
+```js
+const reader = client.loki.createReader({ orgId: 'tenant-a' });
+
+// instant query
+const res = await reader.query('{job="api"}', new Date());
+
+// range query
+const res = await reader.queryRange('{job="api"}', startMs, endMs, '15s', 100, 'backward');
+
+// label names and values
+const labels = await reader.labels();
+const values = await reader.labelValues('job');
+
+// series
+const series = await reader.series(['{job="api"}']);
+```
+
+All reader methods accept the same per-call `opts` described above as their last argument.
+
+### New Tempo methods
+
+```js
+// list all tag keys (scope: 'span' | 'resource' | 'intrinsic')
+const tags = await client.tempo.searchTags('resource');
+
+// list values for a tag key (v1)
+const vals = await client.tempo.searchTagValues('service.name');
+
+// fetch all spans for a trace (alias of getTraceSpansJson)
+const trace = await client.tempo.getTrace('abc123def456');
+```
+
+---
+
 ## Usage
 
 ### Creating a qryn-client Instance
@@ -23,17 +171,16 @@ const { QrynClient } = require('qryn-client');
 
 const client = new QrynClient({
   baseUrl: 'https://qryn.example.com',
-  auth: {
-    username: 'your-username',
-    password: 'your-password'
-  },
-  timeout: 5000
+  auth: { type: 'basic', username: 'your-username', password: 'your-password' },
+  timeout: 60000
 });
 ```
 
 - `baseUrl`: The base URL of the Qryn API. Defaults to `http://localhost:3100`.
-- `auth`: An object containing the authentication credentials (`username` and `password`).
-- `timeout`: The timeout value in milliseconds for API requests. Defaults to `5000`.
+- `auth`: Auth config — see [Migration to 1.1.0 → Auth shapes](#auth-shapes) for the full discriminated-union surface.
+- `timeout`: Per-request timeout in milliseconds. Defaults to `60000`.
+- `retry`: Default retry policy `{ attempts, baseDelayMs, maxDelayMs }`. Defaults to `{ attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 }`.
+- `defaultOrgId`: Sent as `X-Scope-OrgID` on every request when set.
 - `headers`: Optional. Extra default headers merged into every request (e.g. `{ 'X-Custom': 'value' }`).
 
 You can create multiple instances of QrynClient with different configurations for backup purposes.
@@ -268,22 +415,19 @@ const promResponse = await client.prom.push([memoryUsed, cpuUsed]).catch(error =
 qryn-client allows you to configure various options when creating an instance. Here are the available configuration options:
 
 - `baseUrl` (optional): The base URL of the Qryn API. Default is `http://localhost:3100`.
-- `auth` (optional): An object containing the authentication credentials.
-  - `username`: The username for authentication.
-  - `password`: The password for authentication.
-- `timeout` (optional): The timeout value in milliseconds for API requests. Default is `5000`.
+- `auth` (optional): Auth config. Accepted shapes: `{ type: 'basic', username, password }`, `{ type: 'bearer', token }`, `{ type: 'custom', headers }`. See [Migration to 1.1.0 → Auth shapes](#auth-shapes).
+- `timeout` (optional): Per-request timeout in milliseconds. Default is `60000`.
+- `retry` (optional): Default retry policy `{ attempts, baseDelayMs, maxDelayMs }`. Default is `{ attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 }`.
+- `defaultOrgId` (optional): Sent as `X-Scope-OrgID` on every request when set.
 - `headers` (optional): Extra default headers merged into every request. `Content-Type: application/json` is set by default and can be overridden here.
-
-You can pass these options when creating a new instance of qryn-client:
 
 ```javascript
 const client = new QrynClient({
   baseUrl: 'https://qryn.example.com',
-  auth: {
-    username: 'your-username',
-    password: 'your-password'
-  },
-  timeout: 5000
+  auth: { type: 'basic', username: 'your-username', password: 'your-password' },
+  timeout: 60000,
+  retry: { attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 },
+  defaultOrgId: 'my-tenant'
 });
 ```
 
@@ -297,10 +441,10 @@ Creates a new instance of QrynClient.
 
 - `options` (object):
   - `baseUrl` (string): The base URL of the Qryn API. Defaults to `http://localhost:3100`.
-  - `auth` (object):
-    - `username` (string): The username for authentication.
-    - `password` (string): The password for authentication.
-  - `timeout` (number): The timeout value in milliseconds for API requests. Defaults to `5000`.
+  - `auth` (`QrynAuth | { username, password }`): Auth config. See [Auth shapes](#auth-shapes).
+  - `timeout` (number): Per-request timeout in milliseconds. Defaults to `60000`.
+  - `retry` (object): Default retry policy `{ attempts, baseDelayMs, maxDelayMs }`. Defaults to `{ attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 }`.
+  - `defaultOrgId` (string): Sent as `X-Scope-OrgID` on every request when set.
   - `headers` (object): Optional extra default headers merged into every request.
 
 #### `createCollector(options)`
@@ -400,14 +544,28 @@ Returns a new `Metric` instance.
 
 ### Tempo
 
-Accessed via `client.tempo`. All methods return a `Promise<QrynResponse>` and throw `QrynError` on failure.
+Accessed via `client.tempo`. All methods return a `Promise<QrynResponse>` and throw `QrynError` on failure. All `options` accept the per-call opts shape `{ signal, timeoutMs, retry, orgId }`.
 
 #### `search(searchParams, options?)`
 
 Free-form trace search against `/api/search`.
 
-- `searchParams` (string | URLSearchParams): query string (without leading `?`).
-- `options.orgId` (string, optional): multi-tenant routing.
+- `searchParams` (string | URLSearchParams | `{ q, start?, end?, limit?, spss? }`): query params.
+- `options` (object, optional): per-call opts.
+
+#### `searchTags(scope?, options?)`
+
+Returns all tag keys. New in 1.1.0.
+
+- `scope` (`'span' | 'resource' | 'intrinsic'`, optional): filter by scope.
+- `options` (object, optional): per-call opts.
+
+#### `searchTagValues(tagName, options?)`
+
+Returns values for a tag key using Tempo's v1 search API. New in 1.1.0.
+
+- `tagName` (string): e.g. `service.name`.
+- `options` (object, optional): per-call opts.
 
 #### `searchTagValuesV2(tagName, searchParams?, options?)`
 
@@ -415,14 +573,21 @@ Returns the values for a given tag using Tempo's v2 search API.
 
 - `tagName` (string): e.g. `service.name`.
 - `searchParams` (string | URLSearchParams, optional).
-- `options.orgId` (string, optional).
+- `options` (object, optional): per-call opts.
+
+#### `getTrace(traceID, options?)`
+
+Fetches the full JSON span payload for a single trace. New in 1.1.0; alias of `getTraceSpansJson`.
+
+- `traceID` (string): hex-encoded trace id.
+- `options` (object, optional): per-call opts.
 
 #### `getTraceSpansJson(traceID, options?)`
 
 Fetches the full JSON span payload for a single trace.
 
 - `traceID` (string): hex-encoded trace id.
-- `options.orgId` (string, optional).
+- `options` (object, optional): per-call opts.
 
 ### Read
 
@@ -482,6 +647,63 @@ Returns a promise that resolves to the response from the series endpoint.
 Retrieve the currently loaded alerting and recording rules.
 
 Returns a promise that resolves to the response from the rules endpoint.
+
+### LokiReader
+
+Accessed via `client.loki.createReader(options?)`. All methods return a `Promise<QrynResponse>` and throw `QrynError` on failure. Every method accepts a trailing `opts` argument `{ signal, timeoutMs, retry, orgId }`.
+
+#### `constructor(service, options?)`
+
+- `options.orgId` (string, optional): applied to every request made through this reader instance.
+
+#### `query(query, time?, opts?)`
+
+Instant LogQL query.
+
+- `query` (string): LogQL query string.
+- `time` (Date | number | string, optional): evaluation timestamp.
+
+#### `queryRange(query, start, end, step?, limit?, direction?, opts?)`
+
+Range LogQL query.
+
+- `query` (string): LogQL query string.
+- `start`, `end` (Date | number | string): time range.
+- `step` (string, optional): e.g. `'15s'`.
+- `limit` (number, optional): max entries to return.
+- `direction` (`'forward' | 'backward'`, optional).
+
+#### `labels(start?, end?, opts?)`
+
+Returns all label names.
+
+#### `labelValues(label, start?, end?, match?, opts?)`
+
+Returns values for a single label name.
+
+- `label` (string): label name (required).
+
+#### `series(matchers, start?, end?, opts?)`
+
+Returns series matching one or more matchers.
+
+- `matchers` (string | string[]): one or more LogQL stream matchers, e.g. `['{job="api"}']`.
+
+### Errors
+
+All errors extend `QrynError`. New in 1.1.0:
+
+#### `QrynAbortedError`
+
+Thrown when a request is cancelled via an `AbortSignal`. Carries `cause` (the abort reason).
+
+#### `QrynTimeoutError`
+
+Thrown when the per-request timeout fires. Carries `durationMs` (elapsed ms at the point of abort).
+
+```js
+const { QrynAbortedError, QrynTimeoutError, QrynError } = require('qryn-client');
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,23 @@ const client = new QrynClient({
 });
 ```
 
-- `baseUrl`: The base URL of the Qryn API.
+- `baseUrl`: The base URL of the Qryn API. Defaults to `http://localhost:3100`.
 - `auth`: An object containing the authentication credentials (`username` and `password`).
-- `timeout`: The timeout value in milliseconds for API requests.
+- `timeout`: The timeout value in milliseconds for API requests. Defaults to `5000`.
+- `headers`: Optional. Extra default headers merged into every request (e.g. `{ 'X-Custom': 'value' }`).
 
 You can create multiple instances of QrynClient with different configurations for backup purposes.
+
+### Per-push options
+
+`loki.push` and `prom.push` accept a second `options` argument. The same options are honored by `Collector` if you set them at the collector level.
+
+| Option | Header | Effect |
+|---|---|---|
+| `orgId` | `X-Scope-OrgID` | Multi-tenant routing. |
+| `async` | `X-Async-Insert` | Non-blocking insert (faster but lossy). |
+| `fpLimit` | `X-FP-Limit` | Cap on the number of time-series fingerprints stored. |
+| `ttlDays` | `X-Ttl-Days` | Retention override for the push. |
 
 ### Pushing Logs to Loki
 
@@ -92,18 +104,41 @@ console.log('Prometheus push successful:', promResponse);
 - Use `client.prom.push()` to push an array of metrics to Prometheus.
 - You can catch any errors and fallback to a backup client if needed.
 
+### Searching Traces with Tempo
+
+The `tempo` sub-client exposes Tempo's search and trace-fetch endpoints.
+
+```javascript
+// Free-form search (Tempo `/api/search`)
+const search = await client.tempo.search('tags=service.name=auth-svc&limit=20');
+console.log(search.response);
+
+// Tag-value lookup (Tempo v2 `/api/v2/search/tag/{name}/values`)
+const tagValues = await client.tempo.searchTagValuesV2('service.name');
+console.log(tagValues.response);
+
+// Fetch all spans for a single trace
+const trace = await client.tempo.getTraceSpansJson('abc123def456...');
+console.log(trace.response);
+```
+
+All Tempo methods accept an optional `{ orgId }` second argument that maps to the `X-Scope-OrgID` header for multi-tenant deployments. Errors throw `QrynError` (matching Loki and Prometheus), so the same `.catch()`-based failover pattern applies.
+
 ### Using the Collector
 
 The `Collector` class provides a convenient way to collect and push streams and metrics to Qryn. It automatically handles the bulk pushing of data based on the specified maximum bulk size and timeout.
 
 ```javascript
-const { Collector } = require('qryn-client');
-
-const collector = new Collector(client, {
+// Either of these forms works — prefer the factory:
+const collector = client.createCollector({
   maxBulkSize: 1000,
   maxTimeout: 5000,
   orgId: 'your-org-id'
 });
+
+// Or, equivalently:
+const { Collector } = require('qryn-client');
+const collector2 = new Collector(client, { /* same options */ });
 
 const stream = collector.createStream({ job: 'job1', env: 'prod' });
 stream.addEntry(Date.now(), 'Log message 1');
@@ -115,13 +150,23 @@ const metric = collector.createMetric({
 metric.addSample(1024 * 1024 * 100);
 ```
 
-- Create a new instance of `Collector` by passing the `QrynClient` instance and the desired options.
-  - `maxBulkSize`: The maximum bulk size for pushing data. Default is `1000`.
-  - `maxTimeout`: The maximum timeout for pushing data in milliseconds. Default is `5000`.
-  - `orgId`: The organization ID.
-- Use `collector.createStream()` to create a new stream with the desired labels.
+#### Collector options
+
+| Option | Default | Description |
+|---|---|---|
+| `maxBulkSize` | `1000` | Push when total entries+samples reach this count. |
+| `maxTimeout` | `5000` | Push if no activity for this many ms (resets on every add). |
+| `orgId` | — | Multi-tenant routing → `X-Scope-OrgID` on every push. |
+| `async` | — | Non-blocking insert → `X-Async-Insert`. Faster but lossy. |
+| `fpLimit` | — | Fingerprint cap → `X-FP-Limit`. |
+| `ttlDays` | — | Retention override → `X-Ttl-Days`. |
+| `retryAttempts` | `3` | Total push attempts before emitting `'error'`. |
+| `retryDelay` | `1000` | Base delay (ms) for exponential backoff between retries. |
+| `cache` | LRU defaults below | Passed to [`lru-cache`](https://www.npmjs.com/package/lru-cache). Defaults: `max=10000`, `ttl=3600000`, `updateAgeOnGet=true`, `allowStale=false`. |
+
+- Use `collector.createStream()` to create a new stream with the desired labels. Repeated calls with the same labels return the existing instance (deduped by label-set key).
 - Use `stream.addEntry()` to add log entries to the stream.
-- Use `collector.createMetric()` to create a new metric with the desired name and labels.
+- Use `collector.createMetric()` to create a new metric with the desired name and labels. Same deduplication applies.
 - Use `metric.addSample()` to add samples to the metric.
 - The collector will automatically push the collected streams and metrics to Qryn when the maximum bulk size is reached or the timeout expires.
 
@@ -222,11 +267,12 @@ const promResponse = await client.prom.push([memoryUsed, cpuUsed]).catch(error =
 
 qryn-client allows you to configure various options when creating an instance. Here are the available configuration options:
 
-- `baseUrl` (required): The base URL of the Qryn API.
-- `auth` (required): An object containing the authentication credentials.
+- `baseUrl` (optional): The base URL of the Qryn API. Default is `http://localhost:3100`.
+- `auth` (optional): An object containing the authentication credentials.
   - `username`: The username for authentication.
   - `password`: The password for authentication.
 - `timeout` (optional): The timeout value in milliseconds for API requests. Default is `5000`.
+- `headers` (optional): Extra default headers merged into every request. `Content-Type: application/json` is set by default and can be overridden here.
 
 You can pass these options when creating a new instance of qryn-client:
 
@@ -250,11 +296,18 @@ const client = new QrynClient({
 Creates a new instance of QrynClient.
 
 - `options` (object):
-  - `baseUrl` (string): The base URL of the Qryn API.
+  - `baseUrl` (string): The base URL of the Qryn API. Defaults to `http://localhost:3100`.
   - `auth` (object):
     - `username` (string): The username for authentication.
     - `password` (string): The password for authentication.
-  - `timeout` (number): The timeout value in milliseconds for API requests.
+  - `timeout` (number): The timeout value in milliseconds for API requests. Defaults to `5000`.
+  - `headers` (object): Optional extra default headers merged into every request.
+
+#### `createCollector(options)`
+
+Creates a new `Collector` bound to this client. See the [Collector options table](#collector-options) for the full surface.
+
+Returns a new `Collector` instance.
 
 #### `createStream(labels)`
 
@@ -309,13 +362,23 @@ Adds a sample to the metric.
 
 #### `constructor(qrynClient, options)`
 
-Creates a new instance of Collector.
+Creates a new instance of Collector. Prefer `client.createCollector(options)` for new code.
 
 - `qrynClient` (object): The QrynClient instance.
-- `options` (object):
-  - `maxBulkSize` (number): The maximum bulk size for pushing data. Default is `1000`.
-  - `maxTimeout` (number): The maximum timeout for pushing data in milliseconds. Default is `5000`.
-  - `orgId` (string): The organization ID.
+- `options` (object): see the [Collector options table](#collector-options) for all fields. Headline options:
+  - `maxBulkSize` (number, default `1000`).
+  - `maxTimeout` (number, default `5000`).
+  - `orgId` (string).
+  - `async`, `fpLimit`, `ttlDays` — passed through as headers on every push.
+  - `retryAttempts` (default `3`), `retryDelay` (default `1000`).
+  - `cache` — `lru-cache` options, see [Collector options table](#collector-options).
+
+#### Events
+
+Emitted via the standard `EventEmitter` interface:
+
+- `'info'` — fired with the `QrynResponse` after a successful push.
+- `'error'` — fired with a `QrynError` when all retry attempts have been exhausted.
 
 #### `createStream(labels)`
 
@@ -334,6 +397,32 @@ Creates a new metric with the specified options and adds it to the collector.
   - `labels` (object): An object containing the labels for the metric.
 
 Returns a new `Metric` instance.
+
+### Tempo
+
+Accessed via `client.tempo`. All methods return a `Promise<QrynResponse>` and throw `QrynError` on failure.
+
+#### `search(searchParams, options?)`
+
+Free-form trace search against `/api/search`.
+
+- `searchParams` (string | URLSearchParams): query string (without leading `?`).
+- `options.orgId` (string, optional): multi-tenant routing.
+
+#### `searchTagValuesV2(tagName, searchParams?, options?)`
+
+Returns the values for a given tag using Tempo's v2 search API.
+
+- `tagName` (string): e.g. `service.name`.
+- `searchParams` (string | URLSearchParams, optional).
+- `options.orgId` (string, optional).
+
+#### `getTraceSpansJson(traceID, options?)`
+
+Fetches the full JSON span payload for a single trace.
+
+- `traceID` (string): hex-encoded trace id.
+- `options.orgId` (string, optional).
 
 ### Read
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,0 +1,116 @@
+# Audit — 2026-05-02
+
+A snapshot of `qryn-client` at commit `d5fbe7b` (main). Performed as part of the coding-agent readiness pass.
+
+This document is a **point-in-time** record. For the live state of agent guidance, see [`../AGENTS.md`](../AGENTS.md). For ongoing follow-ups, see [`todo.md`](todo.md).
+
+## Summary
+
+| Area | Status |
+|---|---|
+| Documentation completeness | Partial → **fixed in this PR** |
+| JSDoc coverage | Partial → **fixed in this PR** |
+| Public API surface stability | Mostly stable, one typo bug surfaced |
+| Test coverage | None — tracked in `todo.md` |
+| CI / release | Functional (`npm_release.yml`) |
+| Agent readiness | Missing → **created in this PR** (`AGENTS.md`, `CLAUDE.md`, `.aiexclude`, `docs/`) |
+
+## Documentation gaps (FIXED)
+
+Found in `README.md` at audit time:
+
+| Gap | Resolution |
+|---|---|
+| Tempo client (`client.tempo`) was entirely undocumented. | Added a "Searching Traces with Tempo" section to `README.md`. |
+| `client.createCollector(opts)` — exists in `src/index.js` but README only documents the standalone `new Collector(...)` form. | Documented `createCollector` as the canonical entry. |
+| `Collector` options `async`, `fpLimit`, `ttlDays`, `retryAttempts`, `retryDelay`, `cache` were undocumented. README listed only `maxBulkSize`, `maxTimeout`, `orgId`. | Full options table added. |
+| `QrynClient` constructor option `headers` (extra default headers) was undocumented. | Added to constructor docs. |
+| `Read.queryRange` argument types: README said `start`/`end` were "in seconds" but the example uses `Math.floor(Date.now() / 1000)` and the implementation just forwards values. | Clarified in README that callers must pass Unix-second timestamps. |
+| Repository URL placeholder: `package.json` had `https://github.com/username/qryn-client.git`. | Fixed to `https://github.com/metrico/qryn-client.git`. |
+| `searchTagValuesV2(tagName, params)` and `getTraceSpansJson(traceID)` (added in commits `5657f28`, `ad6d7d5`) were undocumented. | Documented in the new Tempo section. |
+
+## JSDoc gaps (FIXED)
+
+| File | Gap | Resolution |
+|---|---|---|
+| `src/clients/tempo.js` | No JSDoc on any method. | Full JSDoc added. |
+| `src/utils/collector.js` | `cache` option JSDoc tag points at `LRUCache.Options` but several other tags are misnamed (e.g. `maxEntries` doesn't exist; the field is `maxBulkSize`). | Aligned tags with actual fields. |
+| `src/clients/loki.js` | `headers(options)` method had no JSDoc. | Added. |
+
+## Code bugs (FIXED in this PR)
+
+Each item lists the file:line, the broken behavior, and what the fix changes.
+
+### B1 — Swapped `fpLimit` / `ttlDays` headers
+
+- **Files:** [`src/clients/loki.js:59-60`](../src/clients/loki.js#L59-L60), [`src/clients/prometheus.js:213-214`](../src/clients/prometheus.js#L213-L214)
+- **Before:**
+  ```js
+  if (options.fpLimit) headers['X-Ttl-Days']  = options.fpLimit;
+  if (options.ttlDays) headers['X-FP-LIMIT']  = options.ttlDays;
+  ```
+- **After:**
+  ```js
+  if (options.fpLimit) headers['X-FP-Limit'] = options.fpLimit;
+  if (options.ttlDays) headers['X-Ttl-Days'] = options.ttlDays;
+  ```
+- **Backward-compat note:** Anyone passing `fpLimit` was actually setting a TTL, and vice versa. Behavior changes for both options. If you depended on the swap, update your option names.
+
+### B2 — `QrynResponse.getData()` returned undefined
+
+- **File:** [`src/types/qrynResponse.js:33`](../src/types/qrynResponse.js#L33)
+- **Before:** `getData() { return this.data; }` — `this.data` was never assigned; the response body lives on `this.response`.
+- **After:** `getData() { return this.response; }`
+- **Backward-compat note:** Code that called `.getData()` and checked for truthiness would have always taken the falsy branch. Such code was already broken; the fix surfaces real data.
+
+### B3 — `Http.request()` only parsed body when **request** was form-urlencoded
+
+- **File:** [`src/services/http.js:63-65`](../src/services/http.js#L63-L65)
+- **Before:**
+  ```js
+  if (headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+    res = await response.json();
+  }
+  ```
+  This checks the *request* `Content-Type`, so JSON-bodied requests (e.g., Loki push) always returned `response: {}` even on success. Worse, error bodies were also dropped, hiding server-side error detail.
+- **After:** parse based on the response `Content-Type` and gracefully handle non-JSON / 204 / empty bodies.
+- **Backward-compat note:** Consumers reading the response body directly will start seeing actual content. The `QrynResponse` shape is unchanged — `response` was always meant to hold the body.
+
+### B4 — `Tempo.search()` swallowed errors
+
+- **File:** [`src/clients/tempo.js:15-17`](../src/clients/tempo.js#L15-L17)
+- **Before:**
+  ```js
+  return this.service.request(...).catch(error => {
+    console.error('ERROR:', error);
+  });
+  ```
+  Returned `undefined` on failure and broke the `.catch()`-based failover documented for the other clients in the README.
+- **After:** errors propagate as `QrynError`, matching the Loki / Prometheus pattern.
+- **Backward-compat note:** Code that did `const r = await tempo.search(); if (!r) ...` will now see a thrown error instead of an `undefined` return. Wrap in `try/catch` or `.catch()`.
+
+## Code observations (NOT bugs, kept as-is)
+
+These looked suspicious during the audit but are correct on close reading. Documented here so future agents don't re-investigate.
+
+- **`Loki.push` / `Prometheus.push` validators using `every()` with side-effects.** The `return s` inside the callback runs unconditionally for `instanceof Stream` (or `Metric`) — the indentation is misleading but the behavior is correct: empty streams are silently skipped, non-Stream values fail the `every()` check. Functional but ugly. Could be refactored to a clear two-pass `filter` + `validate`. Tracked as quality polish in `todo.md`.
+- **`Stream.collect()` clears `entries`.** Intentional — the snapshot lives in `#collectedEntries` for `undo()` to restore. Do not change without breaking the confirm/undo lifecycle.
+- **Collector pushes the entire LRU cache on every flush.** Empty streams/metrics are filtered downstream by the client-side validators, so only models with new data hit the wire. This is intentional and load-bearing for retry semantics.
+
+## Infrastructure
+
+- **CI:** [`.github/workflows/npm_release.yml`](../.github/workflows/npm_release.yml) publishes on GitHub Release events. Functional. Uses `secrets.NPM_TOKEN`.
+- **Dependabot:** Configured in `.github/dependabot.yml` (not inspected; assumed minimal).
+- **No PR validation workflow** — no test, no lint, no type check on PRs. Tracked in `todo.md`.
+- **No `package-lock.json`** is committed. This is intentional per the gitignore. If you bump dependencies, do not commit a lockfile.
+- **Node engine:** `>=18.0.0` (uses `fetch`, `AbortSignal.timeout`). Don't drop the engine constraint.
+
+## Agent-readiness gaps (FIXED in this PR)
+
+- No `AGENTS.md`, no `CLAUDE.md`, no agent ignore file, no architecture doc → all created.
+- README was the only entry for both humans and agents → still primary for humans; agents now have `AGENTS.md`.
+- No JSDoc on Tempo → fixed.
+
+## What's left
+
+See [`todo.md`](todo.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,9 +25,10 @@ A one-page mental model of `qryn-client`. For the agent-facing rules of engageme
                          └──────────┘
                                │
                                ▼
-                          fetch + AbortSignal.timeout
-                          basic auth
-                          QrynError on non-2xx / network failure
+                          fetch + AbortSignal.timeout + anySignal
+                          auth (basic/bearer/custom) resolved per-request
+                          retry loop with backoff + jitter
+                          QrynError / QrynAbortedError / QrynTimeoutError
 ```
 
 `QrynClient` constructs one `Http` instance and hands it to all three sub-clients. Sub-clients hold no state of their own beyond the `service` reference.
@@ -122,17 +123,65 @@ The `Collector` (in `src/utils/collector.js`) is an `EventEmitter` that wraps a 
 
 ## HTTP transport
 
-`Http.request(path, options)`:
+`Http.request(path, options)` is a per-call options pipeline. Per-call values for `signal`, `timeoutMs`, `retry`, and `orgId` override the constructor-time defaults.
 
-1. Resolves `path` against `baseUrl` via WHATWG `URL`.
-2. Merges instance headers + per-call headers.
-3. Adds `Authorization: Basic <base64>` if `auth` was provided.
-4. Calls `fetch` with `signal: AbortSignal.timeout(timeout)`.
-5. Parses the response body based on the **response** `Content-Type`.
-6. Throws `QrynError(message, status, body, path)` on non-OK or network/timeout error.
-7. Returns `QrynResponse` on 2xx.
+### Single-request flow
 
-`QrynError` extends `Error` and carries `statusCode`, `cause` (original error), and `path`. `QrynResponse` wraps body + status + headers and exposes `isSuccess`, `getHeaders`, `getHeader(name)`.
+1. Resolve `path` against `baseUrl` via WHATWG `URL`.
+2. Compute effective timeout: `options.timeoutMs ?? this.timeout` (default `60_000` ms).
+3. Await `resolveAuthHeaders(auth)` to get `Authorization` / custom headers (see [Auth](#auth)).
+4. Resolve `orgId`: `options.orgId ?? this.defaultOrgId`.
+5. Merge headers: instance headers → per-call headers → auth headers → `X-Scope-OrgID` if orgId is set.
+6. Build combined `AbortSignal`: `anySignal([options.signal, AbortSignal.timeout(effectiveTimeout)])`.
+7. Call `fetch`. On `AbortError`:
+   - If `options.signal.aborted` → throw `QrynAbortedError`.
+   - Otherwise → throw `QrynTimeoutError(durationMs)`.
+   - Other network errors → throw `QrynError`.
+8. Parse response body from **response** `Content-Type` (`application/json` → JSON, other → text).
+9. Throw `QrynError(message, status, cause, path)` on non-OK.
+10. Return `QrynResponse` on 2xx.
+
+### Retry loop
+
+`Http.request` wraps `#singleRequest` in a retry loop driven by `RetryOptions`:
+
+```
+{ attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 }   ← defaults
+```
+
+Retry policy:
+- **Never retry** on `QrynAbortedError` (caller cancelled).
+- **Retry** on network errors: `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`.
+- **Retry** on HTTP `408 / 429 / 502 / 503 / 504`. Never retry other 4xx.
+- On HTTP 429, honor `Retry-After` response header (seconds or RFC 7231 date).
+- Delay between attempts uses **exponential backoff with full jitter**: `jitter * min(maxDelayMs, baseDelayMs * 2^(attempt-1))`.
+- Per-call `options.retry` overrides constructor-level `retry`, which overrides the built-in default.
+
+### Error types
+
+| Class | When thrown | Extra fields |
+|---|---|---|
+| `QrynError` | non-2xx response, unrecognised network error | `statusCode`, `cause`, `path` |
+| `QrynAbortedError` | `AbortSignal` fired by caller | `cause` (abort reason) |
+| `QrynTimeoutError` | per-request timeout fired | `durationMs` |
+
+`QrynAbortedError` and `QrynTimeoutError` both extend `QrynError`.
+
+## Auth
+
+Auth is a discriminated union resolved per-request by `resolveAuthHeaders(auth)`.
+
+| `type` | Config | Header produced |
+|---|---|---|
+| `'basic'` | `{ username, password }` | `Authorization: Basic <base64>` |
+| `'bearer'` | `{ token: string \| () => Promise<string> }` | `Authorization: Bearer <token>` |
+| `'custom'` | `{ headers: Record<string,string> \| () => Promise<Record<string,string>> }` | Spread directly into request headers |
+
+For `'bearer'` and `'custom'`, if the value is a function it is **awaited each request**, enabling token-refresh without recreating the client.
+
+### Legacy shape
+
+Constructing with `auth: { username, password }` (no `type`) is still accepted. It is coerced to `{ type: 'basic', ... }` internally and fires `process.emitWarning(..., 'DeprecationWarning', 'QRYN_AUTH_LEGACY')` once per process. The legacy shape will be removed in 2.0.0.
 
 ## Wire formats
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,158 @@
+# Architecture
+
+A one-page mental model of `qryn-client`. For the agent-facing rules of engagement, see [`../AGENTS.md`](../AGENTS.md).
+
+## Component graph
+
+```
+                         ┌──────────────┐
+                         │  QrynClient  │  (src/index.js)
+                         └──────┬───────┘
+                                │ composes
+            ┌───────────────────┼───────────────────┐
+            ▼                   ▼                   ▼
+      ┌──────────┐       ┌────────────┐      ┌──────────┐
+      │   Loki   │       │ Prometheus │      │  Tempo   │
+      │  client  │       │   client   │      │  client  │
+      │  (logs)  │       │ (metrics)  │      │ (traces) │
+      └─────┬────┘       └─────┬──────┘      └─────┬────┘
+            │                  │                   │
+            └──────────────────┼───────────────────┘
+                               ▼
+                         ┌──────────┐
+                         │   Http   │   (src/services/http.js)
+                         │ service  │
+                         └──────────┘
+                               │
+                               ▼
+                          fetch + AbortSignal.timeout
+                          basic auth
+                          QrynError on non-2xx / network failure
+```
+
+`QrynClient` constructs one `Http` instance and hands it to all three sub-clients. Sub-clients hold no state of their own beyond the `service` reference.
+
+## Data models
+
+```
+                ┌─────────────┐
+                │   Stream    │  (src/models/stream.js)
+                ├─────────────┤
+                │ labels      │
+                │ entries[]   │ ◄── addEntry(ts, line)
+                │ #cachedKey  │
+                │ #snapshot   │
+                └──────┬──────┘
+                       │ collect() → snapshot + clear
+                       │ confirm() → drop snapshot
+                       │ undo()    → restore snapshot
+                       ▼
+                  ┌─────────┐
+                  │  Loki   │ ── POST /loki/api/v1/push
+                  └─────────┘
+
+                ┌─────────────┐
+                │   Metric    │  (src/models/metric.js)
+                ├─────────────┤
+                │ name        │
+                │ labels      │
+                │ samples[]   │ ◄── addSample(value, ts?)
+                │ #cachedKey  │
+                │ #snapshot   │
+                └──────┬──────┘
+                       │ collect() → snapshot + clear
+                       │ confirm() / undo()
+                       ▼
+                  ┌────────────┐    protobuf-encode + snappy-compress
+                  │ Prometheus │ ── POST /api/v1/prom/remote/write
+                  └────────────┘
+```
+
+The `key` getter on each model produces a stable cache key (label-set hash for streams, name + sorted labels for metrics). The `Collector` uses this key to deduplicate.
+
+## Confirm / undo lifecycle (the most important invariant)
+
+Both `Stream` and `Metric` use the same three-state pattern:
+
+```
+    ┌──────────┐                         ┌────────────┐
+    │ buffered │ ── collect() ─────────▶ │ in-flight  │
+    │ entries  │                         │ (snapshot) │
+    └──────────┘                         └─────┬──────┘
+         ▲                                     │
+         │                                     ├── confirm() → discarded (server 2xx)
+         │                                     │
+         └──── undo() ◄────────────────────────┘   (error: prepend back to buffer)
+```
+
+`collect()` is destructive — it empties the live buffer and stashes a snapshot. From that moment, **exactly one of `confirm()` / `undo()` must be called** before the next `collect()`. The Loki and Prometheus clients are the reference for this discipline.
+
+## Collector batching
+
+The `Collector` (in `src/utils/collector.js`) is an `EventEmitter` that wraps a `QrynClient` and adds:
+
+- **Deduplication.** `createStream` / `createMetric` look up the model by its `key` in an `LRUCache`. Re-creating with the same labels returns the existing instance, so all entries flow into one stream object.
+- **Two flush triggers.** A flush fires when `total entries + samples >= maxBulkSize`, or when `maxTimeout` ms elapse since the last add (the timer is reset on every add).
+- **Retries.** `retryOperation` retries the push up to `retryAttempts` times with exponential backoff (`retryDelay * 2^(attempt-1)`).
+- **Events.** Emits `info` (with the `QrynResponse`) on success, `error` on terminal failure.
+
+```
+       addEntry / addSample
+              │
+              ▼
+       incrementTotal()
+              │
+              ▼
+        total >= max?
+        ┌──── yes ────┐         ┌──── no ────┐
+        ▼             ▼         ▼            ▼
+    pushBulk()   clearTimeout   resetTimeout (maxTimeout)
+        │                          │
+        ▼                          ▼
+    loki.push(streams)         (eventually) pushBulk()
+    prom.push(metrics)
+        │
+   retryOperation(...)
+        │
+   on success → emit('info')
+   on failure → restore counters, emit('error')
+```
+
+**Important:** the `Collector` pushes *all* cached streams/metrics on every flush. The `Stream` / `Metric` `collect()` methods skip empty buffers via the client-side validator, so only models with new data hit the wire. If you change this, you can easily double-push.
+
+## HTTP transport
+
+`Http.request(path, options)`:
+
+1. Resolves `path` against `baseUrl` via WHATWG `URL`.
+2. Merges instance headers + per-call headers.
+3. Adds `Authorization: Basic <base64>` if `auth` was provided.
+4. Calls `fetch` with `signal: AbortSignal.timeout(timeout)`.
+5. Parses the response body based on the **response** `Content-Type`.
+6. Throws `QrynError(message, status, body, path)` on non-OK or network/timeout error.
+7. Returns `QrynResponse` on 2xx.
+
+`QrynError` extends `Error` and carries `statusCode`, `cause` (original error), and `path`. `QrynResponse` wraps body + status + headers and exposes `isSuccess`, `getHeaders`, `getHeader(name)`.
+
+## Wire formats
+
+| Endpoint | Body | Headers |
+|---|---|---|
+| `POST /loki/api/v1/push` | JSON `{ streams: [{ labels, entries }] }` | `Content-Type: application/json` |
+| `POST /api/v1/prom/remote/write` | protobuf-encoded `WriteRequest`, snappy-compressed | `Content-Type: application/x-protobuf`, `Content-Encoding: snappy`, `X-Prometheus-Remote-Write-Version: 0.1.0` |
+| `POST /api/v1/query`, `POST /api/v1/query_range`, `POST /api/v1/series` | `URLSearchParams` | `Content-Type: application/x-www-form-urlencoded` |
+| `GET /api/v1/labels`, `GET /api/v1/label/{name}/values`, `GET /api/v1/rules` | — | — |
+| `GET /api/search`, `GET /api/v2/search/tag/{name}/values`, `GET /api/traces/{id}/json` | — | `Accept: application/json` |
+
+The protobuf schema is vendored at `src/services/remote.proto`. Don't edit it manually — pull from upstream Prometheus when an update is needed.
+
+## Optional headers (push paths)
+
+All push paths accept these per-call options on `push(arr, options)`:
+
+| Option | Header | Effect |
+|---|---|---|
+| `orgId` | `X-Scope-OrgID` | Multi-tenant routing. |
+| `async` | `X-Async-Insert` | Non-blocking insert (qryn-specific; faster but lossy). |
+| `fpLimit` | `X-FP-Limit` | Cap on time-series fingerprints stored. |
+| `ttlDays` | `X-Ttl-Days` | Retention override for the push. |

--- a/docs/superpowers/plans/2026-05-02-qryn-client-v1.1.md
+++ b/docs/superpowers/plans/2026-05-02-qryn-client-v1.1.md
@@ -1,0 +1,2719 @@
+# qryn-client v1.1.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land P0 + P1 of the qryn-client extensions requirements as a non-breaking v1.1.0 minor release: per-call abort/timeout/retry on every HTTP call, pluggable auth (basic/bearer/custom), a new `LokiReader`, alignment of `TempoClient` to the spec surface, and shipped `.d.ts` types.
+
+**Architecture:** All five additions hang off one shared HTTP layer. The first wave of tasks rebuilds [src/services/http.js](../../../src/services/http.js) into a per-call options pipeline (signal, timeoutMs, retry, orgId, async auth resolver). Once that exists, `LokiReader`, `PromReader` opts plumbing, and `TempoClient` additions are all thin layers on top. Type emission happens last — generate `dist/types/` from JSDoc via `tsc --declaration --allowJs`, then hand-augment with [index.d.ts](../../../index.d.ts) for the named response types and `QrynResponse<T>` generics that JSDoc cannot express.
+
+**Tech Stack:** Node ≥ 18, native `fetch`, `AbortSignal.timeout`, `AbortSignal.any` (with a Node-18 polyfill), `node:test` (built-in test runner), `typescript` (devDep, declaration-only), CommonJS source.
+
+**Source spec:** [docs/superpowers/specs/2026-05-02-qryn-client-v1.1-design.md](../specs/2026-05-02-qryn-client-v1.1-design.md)
+
+---
+
+## File map
+
+| File | Status | Responsibility |
+|---|---|---|
+| [src/services/http.js](../../../src/services/http.js) | Modify | Per-call options pipeline. Resolves auth, builds combined signal, runs the retry loop, maps abort/timeout to typed errors. |
+| [src/utils/abort.js](../../../src/utils/abort.js) | Create | `anySignal(signals[])` — wraps `AbortSignal.any` when present, falls back to a controller + listeners on Node 18. Pure utility. |
+| [src/utils/time.js](../../../src/utils/time.js) | Create | `toNanos(input)` — normalizes `Date \| number \| string` to a nanosecond integer string. Pure utility. |
+| [src/utils/retry.js](../../../src/utils/retry.js) | Create | `computeBackoff(attempt, opts)`, `parseRetryAfter(header)`, `isRetryableStatus(n)`, `isRetryableNetworkError(err)`. Pure helpers, easy to unit-test. |
+| [src/types/qrynAbortedError.js](../../../src/types/qrynAbortedError.js) | Create | `class QrynAbortedError extends QrynError`. |
+| [src/types/qrynTimeoutError.js](../../../src/types/qrynTimeoutError.js) | Create | `class QrynTimeoutError extends QrynError`. |
+| [src/types/index.js](../../../src/types/index.js) | Modify | Re-export the two new error classes. |
+| [src/index.js](../../../src/index.js) | Modify | Constructor accepts `auth` (discriminated union), `retry`, `defaultOrgId`. Runs the legacy-auth `process.emitWarning` shim. Exposes new errors. |
+| [src/clients/loki.js](../../../src/clients/loki.js) | Modify | Add `createReader(options)` factory. `push` plumbs through new opts. |
+| [src/clients/loki-read.js](../../../src/clients/loki-read.js) | Create | `LokiReader` — `query`, `queryRange`, `labels`, `labelValues`, `series`. |
+| [src/clients/prometheus.js](../../../src/clients/prometheus.js) | Modify | `Read` methods grow optional `opts` trailing arg. `push` plumbs through. |
+| [src/clients/tempo.js](../../../src/clients/tempo.js) | Modify | New methods `searchTags`, `searchTagValues`, `getTrace` (alias). Existing methods grow `opts`. |
+| [tests/unit/abort.test.js](../../../tests/unit/abort.test.js) | Create | Unit test for `anySignal`. |
+| [tests/unit/time.test.js](../../../tests/unit/time.test.js) | Create | Unit test for `toNanos`. |
+| [tests/unit/retry.test.js](../../../tests/unit/retry.test.js) | Create | Unit test for retry helpers. |
+| [tests/unit/auth.test.js](../../../tests/unit/auth.test.js) | Create | Unit test for legacy-auth shim + auth resolution. |
+| [tests/unit/http.test.js](../../../tests/unit/http.test.js) | Create | Unit test for `Http.request` opts pipeline (mocked `fetch`). |
+| [tests/unit/loki-read.test.js](../../../tests/unit/loki-read.test.js) | Create | Unit test for `LokiReader` URL building (mocked `fetch`). |
+| [tests/unit/tempo.test.js](../../../tests/unit/tempo.test.js) | Create | Unit test for new tempo methods (mocked `fetch`). |
+| [tests/types/consumer-smoke.ts](../../../tests/types/consumer-smoke.ts) | Create | Strict TS consumer that imports the public surface. |
+| [tsconfig.json](../../../tsconfig.json) | Create | Bare-minimum config for `tsc --declaration` and the consumer smoke. |
+| [index.d.ts](../../../index.d.ts) | Create | Hand-written augmentation: re-exports JSDoc-derived `dist/types/index.d.ts`, plus `QrynAuth`, `RetryOptions`, `ReadOpts`, `QrynResponse<T>`, named response types. |
+| [example/loki-read.js](../../../example/loki-read.js) | Create | Manual smoke for the new Loki reader. |
+| [example/tempo.js](../../../example/tempo.js) | Create | Manual smoke for new tempo surface. |
+| [package.json](../../../package.json) | Modify | `types`, `files`, `scripts` (`test`, `build:types`, `test:types`), devDep on `typescript`. Version bump 1.0.10 → 1.1.0 (LAST step before release). |
+| [README.md](../../../README.md) | Modify | Document new auth shape, `client.loki.createReader()`, tempo additions, retry/abort, the deprecation. Add a "Migration to 1.1.0" section. |
+| [docs/architecture.md](../../../docs/architecture.md) | Modify | Update the HTTP/auth section. |
+
+`docs/AUDIT.md`, `docs/todo.md`, `.github/workflows/npm_release.yml` are not modified by this plan unless explicitly noted in a task.
+
+## Verification notes for the executing engineer
+
+- This repo has no test runner today (`npm test` exits 1). Task 1 sets up `node:test` minimally. Do **not** add Jest, Mocha, vitest, or any other test framework.
+- Default file format: CommonJS (`require` / `module.exports`). Do NOT introduce ESM. Use `require` everywhere in `src/`.
+- Indentation is 2 spaces, single quotes. Match the surrounding style. Do not run a formatter.
+- Errors thrown at module boundaries must be `QrynError` (or a subclass). Never `console.error` and swallow.
+- `Stream` and `Metric` lifecycle (collect → confirm/undo) is sacred — see [AGENTS.md §5](../../../AGENTS.md). None of these tasks touch that path, but if you find yourself editing `Loki.push` or `Prometheus.push` beyond plumbing options into `service.request(...)`, you've drifted off-plan.
+- Some pitfalls to avoid in `Http.request` are documented in [AGENTS.md §10](../../../AGENTS.md). Re-read that section before Task 6.
+- Commits use the existing project style: short, lowercase, imperative. Examples in `git log`. **Do NOT use Conventional Commits prefixes** (`feat:`, `fix:`) — the project does not use them.
+- Each task ends with a commit. Frequent commits are mandatory.
+
+---
+
+## Task 1: Set up minimal test runner
+
+**Files:**
+- Modify: [package.json](../../../package.json) — `scripts.test`
+- Create: [tests/unit/.gitkeep](../../../tests/unit/.gitkeep)
+- Create: [tests/unit/sanity.test.js](../../../tests/unit/sanity.test.js)
+
+- [ ] **Step 1: Wire `node:test` as the test runner**
+
+Edit [package.json](../../../package.json). Replace the `test` script:
+
+```json
+"scripts": {
+  "test": "node --test tests/unit/"
+}
+```
+
+- [ ] **Step 2: Create a sanity test that proves the runner works**
+
+Create [tests/unit/sanity.test.js](../../../tests/unit/sanity.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('runner is alive', () => {
+  assert.equal(1 + 1, 2);
+});
+```
+
+- [ ] **Step 3: Run the sanity test**
+
+Run: `npm test`
+Expected: `# pass 1` and exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json tests/unit/sanity.test.js
+git commit -m "wire node:test as the test runner"
+```
+
+---
+
+## Task 2: `anySignal` — combine AbortSignals (Node-18 compatible)
+
+**Files:**
+- Create: [src/utils/abort.js](../../../src/utils/abort.js)
+- Create: [tests/unit/abort.test.js](../../../tests/unit/abort.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/abort.test.js](../../../tests/unit/abort.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { anySignal } = require('../../src/utils/abort');
+
+test('returns a signal already aborted when an input is already aborted', () => {
+  const a = new AbortController();
+  a.abort('first');
+  const signal = anySignal([a.signal, new AbortController().signal]);
+  assert.equal(signal.aborted, true);
+});
+
+test('aborts when the first input aborts', () => {
+  const a = new AbortController();
+  const b = new AbortController();
+  const signal = anySignal([a.signal, b.signal]);
+  assert.equal(signal.aborted, false);
+  a.abort('boom');
+  assert.equal(signal.aborted, true);
+});
+
+test('aborts when the second input aborts', () => {
+  const a = new AbortController();
+  const b = new AbortController();
+  const signal = anySignal([a.signal, b.signal]);
+  b.abort('boom2');
+  assert.equal(signal.aborted, true);
+});
+
+test('passes the original reason through', () => {
+  const a = new AbortController();
+  const reason = new Error('caller abort');
+  const signal = anySignal([a.signal]);
+  a.abort(reason);
+  assert.equal(signal.reason, reason);
+});
+
+test('drops null/undefined signals', () => {
+  const a = new AbortController();
+  const signal = anySignal([null, undefined, a.signal]);
+  assert.equal(signal.aborted, false);
+  a.abort();
+  assert.equal(signal.aborted, true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module '../../src/utils/abort'`.
+
+- [ ] **Step 3: Implement `anySignal`**
+
+Create [src/utils/abort.js](../../../src/utils/abort.js):
+
+```js
+'use strict';
+
+/**
+ * Returns an AbortSignal that aborts when ANY of the input signals abort.
+ * Wraps `AbortSignal.any` when available (Node 20+); otherwise registers
+ * one-shot listeners on each input signal.
+ *
+ * Null/undefined inputs are silently dropped.
+ *
+ * @param {Array<AbortSignal|null|undefined>} signals
+ * @returns {AbortSignal}
+ */
+function anySignal(signals) {
+  const inputs = signals.filter(s => s != null);
+
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(inputs);
+  }
+
+  const controller = new AbortController();
+
+  // Already aborted? Forward immediately.
+  for (const s of inputs) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+  }
+
+  const onAbort = (event) => {
+    const source = event.target;
+    controller.abort(source.reason);
+    for (const s of inputs) {
+      s.removeEventListener('abort', onAbort);
+    }
+  };
+
+  for (const s of inputs) {
+    s.addEventListener('abort', onAbort, { once: true });
+  }
+
+  return controller.signal;
+}
+
+module.exports = { anySignal };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `abort.test.js` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abort.js tests/unit/abort.test.js
+git commit -m "add anySignal util for combining AbortSignals (Node 18 compatible)"
+```
+
+---
+
+## Task 3: `toNanos` — time normalization for Loki
+
+**Files:**
+- Create: [src/utils/time.js](../../../src/utils/time.js)
+- Create: [tests/unit/time.test.js](../../../tests/unit/time.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/time.test.js](../../../tests/unit/time.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { toNanos } = require('../../src/utils/time');
+
+test('Date → nanoseconds string', () => {
+  const d = new Date(1700000000000); // 2023-11-14T22:13:20Z
+  assert.equal(toNanos(d), '1700000000000000000');
+});
+
+test('seconds heuristic (number < 1e12) → nanoseconds', () => {
+  assert.equal(toNanos(1700000000), '1700000000000000000');
+});
+
+test('milliseconds heuristic (1e12 <= number < 1e15) → nanoseconds', () => {
+  assert.equal(toNanos(1700000000000), '1700000000000000000');
+});
+
+test('nanoseconds heuristic (number >= 1e15) → unchanged (string form)', () => {
+  assert.equal(toNanos(1700000000000000000), '1700000000000000000');
+});
+
+test('string passes through unchanged', () => {
+  assert.equal(toNanos('1700000000000000123'), '1700000000000000123');
+});
+
+test('throws on null/undefined', () => {
+  assert.throws(() => toNanos(null));
+  assert.throws(() => toNanos(undefined));
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `toNanos`**
+
+Create [src/utils/time.js](../../../src/utils/time.js):
+
+```js
+'use strict';
+
+const { QrynError } = require('../types');
+
+/**
+ * Normalize a time input to a nanosecond integer string.
+ * - Date          → milliseconds × 1e6
+ * - number < 1e12 → assumed seconds, multiplied to ns
+ * - number < 1e15 → assumed milliseconds, multiplied to ns
+ * - number ≥ 1e15 → assumed nanoseconds (kept)
+ * - string        → returned unchanged (caller knows the unit)
+ *
+ * Returned as a string to preserve precision beyond Number.MAX_SAFE_INTEGER.
+ *
+ * @param {Date|number|string} input
+ * @returns {string}
+ */
+function toNanos(input) {
+  if (input == null) {
+    throw new QrynError('toNanos: input is required');
+  }
+  if (input instanceof Date) {
+    return (BigInt(input.getTime()) * 1000000n).toString();
+  }
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    if (input < 1e12) {
+      return (BigInt(Math.trunc(input)) * 1000000000n).toString();
+    }
+    if (input < 1e15) {
+      return (BigInt(Math.trunc(input)) * 1000000n).toString();
+    }
+    return BigInt(Math.trunc(input)).toString();
+  }
+  throw new QrynError(`toNanos: unsupported input type ${typeof input}`);
+}
+
+module.exports = { toNanos };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `time.test.js` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/time.js tests/unit/time.test.js
+git commit -m "add toNanos time normalization helper for Loki reader"
+```
+
+---
+
+## Task 4: Retry helpers — pure functions for the policy math
+
+**Files:**
+- Create: [src/utils/retry.js](../../../src/utils/retry.js)
+- Create: [tests/unit/retry.test.js](../../../tests/unit/retry.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/retry.test.js](../../../tests/unit/retry.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+} = require('../../src/utils/retry');
+
+test('DEFAULT_RETRY matches spec defaults', () => {
+  assert.equal(DEFAULT_RETRY.attempts, 3);
+  assert.equal(DEFAULT_RETRY.baseDelayMs, 200);
+  assert.equal(DEFAULT_RETRY.maxDelayMs, 5000);
+});
+
+test('computeBackoff: exponential growth, capped at maxDelayMs', (t) => {
+  // Force jitter to identity for assertable math.
+  const random = () => 1.0;
+  assert.equal(computeBackoff(1, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 200);
+  assert.equal(computeBackoff(2, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 400);
+  assert.equal(computeBackoff(3, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 800);
+  assert.equal(computeBackoff(10, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 5000);
+});
+
+test('computeBackoff: jitter scales the delay by [0,1)', () => {
+  const fixed = computeBackoff(2, { baseDelayMs: 200, maxDelayMs: 5000 }, () => 0.5);
+  assert.equal(fixed, 200);
+});
+
+test('parseRetryAfter: numeric seconds', () => {
+  assert.equal(parseRetryAfter('5'), 5000);
+  assert.equal(parseRetryAfter('0'), 0);
+});
+
+test('parseRetryAfter: HTTP-date', () => {
+  const future = new Date(Date.now() + 3000);
+  const ms = parseRetryAfter(future.toUTCString());
+  assert.ok(ms >= 2000 && ms <= 4000);
+});
+
+test('parseRetryAfter: invalid → null', () => {
+  assert.equal(parseRetryAfter('garbage'), null);
+  assert.equal(parseRetryAfter(undefined), null);
+  assert.equal(parseRetryAfter(null), null);
+});
+
+test('isRetryableStatus: only 408, 429, 502, 503, 504', () => {
+  for (const s of [408, 429, 502, 503, 504]) {
+    assert.equal(isRetryableStatus(s), true, `${s} should be retryable`);
+  }
+  for (const s of [200, 400, 401, 403, 404, 422, 500, 501]) {
+    assert.equal(isRetryableStatus(s), false, `${s} must not be retryable`);
+  }
+});
+
+test('isRetryableNetworkError: known codes', () => {
+  for (const code of ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN']) {
+    assert.equal(isRetryableNetworkError({ code }), true);
+    assert.equal(isRetryableNetworkError({ cause: { code } }), true);
+  }
+  assert.equal(isRetryableNetworkError({ code: 'EPERM' }), false);
+  assert.equal(isRetryableNetworkError(null), false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create [src/utils/retry.js](../../../src/utils/retry.js):
+
+```js
+'use strict';
+
+const DEFAULT_RETRY = Object.freeze({
+  attempts: 3,
+  baseDelayMs: 200,
+  maxDelayMs: 5000
+});
+
+const RETRYABLE_STATUS = new Set([408, 429, 502, 503, 504]);
+const RETRYABLE_NET_CODES = new Set(['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN']);
+
+/**
+ * Exponential backoff with full jitter.
+ * delay = jitter * min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1))
+ *
+ * @param {number} attempt - 1-based attempt number that just failed.
+ * @param {{ baseDelayMs: number, maxDelayMs: number }} opts
+ * @param {() => number} [random=Math.random] - Injected for testing.
+ * @returns {number} delay in milliseconds before the next attempt.
+ */
+function computeBackoff(attempt, opts, random = Math.random) {
+  const exp = opts.baseDelayMs * Math.pow(2, attempt - 1);
+  const capped = Math.min(opts.maxDelayMs, exp);
+  return Math.floor(random() * capped);
+}
+
+/**
+ * Parse a Retry-After header (RFC 7231).
+ * @param {string|null|undefined} value
+ * @returns {number|null} milliseconds to wait, or null if unparseable.
+ */
+function parseRetryAfter(value) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (trimmed === '') return null;
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  const ts = Date.parse(trimmed);
+  if (Number.isNaN(ts)) return null;
+  return Math.max(0, ts - Date.now());
+}
+
+/**
+ * @param {number} status
+ * @returns {boolean}
+ */
+function isRetryableStatus(status) {
+  return RETRYABLE_STATUS.has(status);
+}
+
+/**
+ * @param {{code?: string, cause?: {code?: string}} | null | undefined} err
+ * @returns {boolean}
+ */
+function isRetryableNetworkError(err) {
+  if (!err) return false;
+  if (err.code && RETRYABLE_NET_CODES.has(err.code)) return true;
+  if (err.cause && err.cause.code && RETRYABLE_NET_CODES.has(err.cause.code)) return true;
+  return false;
+}
+
+module.exports = {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `retry.test.js` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/retry.js tests/unit/retry.test.js
+git commit -m "add retry helpers (backoff, retry-after, retryable-status)"
+```
+
+---
+
+## Task 5: New error classes — `QrynAbortedError`, `QrynTimeoutError`
+
+**Files:**
+- Create: [src/types/qrynAbortedError.js](../../../src/types/qrynAbortedError.js)
+- Create: [src/types/qrynTimeoutError.js](../../../src/types/qrynTimeoutError.js)
+- Modify: [src/types/index.js](../../../src/types/index.js)
+
+- [ ] **Step 1: Create `QrynAbortedError`**
+
+Create [src/types/qrynAbortedError.js](../../../src/types/qrynAbortedError.js):
+
+```js
+const QrynError = require('./qrynError');
+
+/**
+ * Thrown when a request is aborted by a caller-supplied AbortSignal.
+ * Distinct from QrynTimeoutError (which signals the request's own timeout fired)
+ * and from network errors.
+ */
+class QrynAbortedError extends QrynError {
+  /**
+   * @param {string} message
+   * @param {*} [reason] - The AbortSignal.reason at abort time, if any.
+   * @param {string} [path]
+   */
+  constructor(message, reason, path) {
+    super(message, null, reason, path);
+    this.name = 'QrynAbortedError';
+    this.reason = reason;
+  }
+}
+
+module.exports = QrynAbortedError;
+```
+
+- [ ] **Step 2: Create `QrynTimeoutError`**
+
+Create [src/types/qrynTimeoutError.js](../../../src/types/qrynTimeoutError.js):
+
+```js
+const QrynError = require('./qrynError');
+
+/**
+ * Thrown when the per-request timeout (timeoutMs) elapses before the
+ * fetch resolves. Distinct from QrynAbortedError (caller-driven) and
+ * from network errors.
+ */
+class QrynTimeoutError extends QrynError {
+  /**
+   * @param {string} message
+   * @param {number} elapsedMs
+   * @param {string} [path]
+   */
+  constructor(message, elapsedMs, path) {
+    super(message, null, undefined, path);
+    this.name = 'QrynTimeoutError';
+    this.elapsedMs = elapsedMs;
+  }
+}
+
+module.exports = QrynTimeoutError;
+```
+
+- [ ] **Step 3: Re-export from types/index.js**
+
+Edit [src/types/index.js](../../../src/types/index.js). The new file content:
+
+```js
+const QrynError = require('./qrynError');
+const QrynResponse = require('./qrynResponse');
+const QrynAbortedError = require('./qrynAbortedError');
+const QrynTimeoutError = require('./qrynTimeoutError');
+
+class NetworkError extends QrynError {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = 'NetworkError';
+    this.statusCode = options.statusCode;
+  }
+}
+
+class ValidationError extends QrynError {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = 'ValidationError';
+    this.field = options.field;
+  }
+}
+
+module.exports = {
+  NetworkError,
+  ValidationError,
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
+  QrynResponse
+};
+```
+
+- [ ] **Step 4: Smoke-check the require graph**
+
+Run: `node -e "const t = require('./src/types'); console.log(Object.keys(t));"`
+Expected: prints `[ 'NetworkError', 'ValidationError', 'QrynError', 'QrynAbortedError', 'QrynTimeoutError', 'QrynResponse' ]`.
+
+- [ ] **Step 5: Run all tests to confirm no regression**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/qrynAbortedError.js src/types/qrynTimeoutError.js src/types/index.js
+git commit -m "add QrynAbortedError and QrynTimeoutError"
+```
+
+---
+
+## Task 6: Auth resolver + legacy-auth back-compat shim
+
+This task introduces the auth pipeline that `Http` will use. The work is split: a small pure resolver helper goes into a new module so it's testable without `fetch`, and the QrynClient constructor gets the shim. `Http` is *not* yet wired to the resolver — that comes in Task 7.
+
+**Files:**
+- Create: [src/services/auth.js](../../../src/services/auth.js)
+- Create: [tests/unit/auth.test.js](../../../tests/unit/auth.test.js)
+- Modify: [src/index.js](../../../src/index.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/auth.test.js](../../../tests/unit/auth.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveAuthHeaders, normalizeAuth } = require('../../src/services/auth');
+
+test('basic: builds Authorization header', async () => {
+  const headers = await resolveAuthHeaders({ type: 'basic', username: 'u', password: 'p' });
+  const expected = 'Basic ' + Buffer.from('u:p').toString('base64');
+  assert.equal(headers.Authorization, expected);
+});
+
+test('bearer: string token', async () => {
+  const headers = await resolveAuthHeaders({ type: 'bearer', token: 'abc' });
+  assert.equal(headers.Authorization, 'Bearer abc');
+});
+
+test('bearer: thunk is awaited each call', async () => {
+  let n = 0;
+  const tokenFn = async () => `token-${++n}`;
+  const a = await resolveAuthHeaders({ type: 'bearer', token: tokenFn });
+  const b = await resolveAuthHeaders({ type: 'bearer', token: tokenFn });
+  assert.equal(a.Authorization, 'Bearer token-1');
+  assert.equal(b.Authorization, 'Bearer token-2');
+});
+
+test('custom: object headers', async () => {
+  const headers = await resolveAuthHeaders({
+    type: 'custom',
+    headers: { 'X-Api-Key': 'abc' }
+  });
+  assert.deepEqual(headers, { 'X-Api-Key': 'abc' });
+});
+
+test('custom: thunk headers', async () => {
+  const headers = await resolveAuthHeaders({
+    type: 'custom',
+    headers: async () => ({ 'X-Api-Key': 'fresh' })
+  });
+  assert.deepEqual(headers, { 'X-Api-Key': 'fresh' });
+});
+
+test('undefined auth → empty headers', async () => {
+  const headers = await resolveAuthHeaders(undefined);
+  assert.deepEqual(headers, {});
+});
+
+test('normalizeAuth: legacy {username,password} coerced to basic', () => {
+  const result = normalizeAuth({ username: 'u', password: 'p' });
+  assert.equal(result.legacy, true);
+  assert.deepEqual(result.auth, { type: 'basic', username: 'u', password: 'p' });
+});
+
+test('normalizeAuth: typed auth passes through', () => {
+  const a = { type: 'bearer', token: 't' };
+  const result = normalizeAuth(a);
+  assert.equal(result.legacy, false);
+  assert.equal(result.auth, a);
+});
+
+test('normalizeAuth: undefined passes through', () => {
+  const result = normalizeAuth(undefined);
+  assert.equal(result.legacy, false);
+  assert.equal(result.auth, undefined);
+});
+
+test('normalizeAuth: unknown type rejected', () => {
+  assert.throws(() => normalizeAuth({ type: 'banana' }));
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the auth module**
+
+Create [src/services/auth.js](../../../src/services/auth.js):
+
+```js
+'use strict';
+
+const { QrynError } = require('../types');
+
+/**
+ * @typedef {Object} BasicAuth
+ * @property {'basic'} type
+ * @property {string} username
+ * @property {string} password
+ *
+ * @typedef {Object} BearerAuth
+ * @property {'bearer'} type
+ * @property {string|(() => Promise<string>)} token
+ *
+ * @typedef {Object} CustomAuth
+ * @property {'custom'} type
+ * @property {Record<string,string>|(() => Promise<Record<string,string>>)} headers
+ *
+ * @typedef {BasicAuth|BearerAuth|CustomAuth} QrynAuth
+ */
+
+/**
+ * Resolve the auth `QrynAuth` config to a header map for the next request.
+ * Bearer/custom thunks are awaited each call so the caller can refresh.
+ *
+ * @param {QrynAuth|undefined} auth
+ * @returns {Promise<Record<string,string>>}
+ */
+async function resolveAuthHeaders(auth) {
+  if (!auth) return {};
+  switch (auth.type) {
+    case 'basic': {
+      const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      return { Authorization: `Basic ${encoded}` };
+    }
+    case 'bearer': {
+      const token = typeof auth.token === 'function' ? await auth.token() : auth.token;
+      return { Authorization: `Bearer ${token}` };
+    }
+    case 'custom': {
+      const h = typeof auth.headers === 'function' ? await auth.headers() : auth.headers;
+      return { ...h };
+    }
+    default:
+      throw new QrynError(`Unsupported auth type: ${auth.type}`);
+  }
+}
+
+/**
+ * Normalize a constructor-time `auth` value: detect the legacy
+ * `{ username, password }` shape and coerce to `{ type: 'basic', ... }`.
+ *
+ * @param {QrynAuth|{username:string,password:string}|undefined} auth
+ * @returns {{ auth: QrynAuth|undefined, legacy: boolean }}
+ */
+function normalizeAuth(auth) {
+  if (!auth) return { auth: undefined, legacy: false };
+  if (!auth.type && auth.username !== undefined) {
+    return {
+      auth: { type: 'basic', username: auth.username, password: auth.password },
+      legacy: true
+    };
+  }
+  if (!['basic', 'bearer', 'custom'].includes(auth.type)) {
+    throw new QrynError(`Unsupported auth type: ${auth.type}`);
+  }
+  return { auth, legacy: false };
+}
+
+module.exports = { resolveAuthHeaders, normalizeAuth };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `auth.test.js` tests pass.
+
+- [ ] **Step 5: Wire the legacy-auth shim into the QrynClient constructor**
+
+Edit [src/index.js](../../../src/index.js). Replace the constructor body. Full new file content:
+
+```js
+const {Stream, Metric} = require('./models');
+const PrometheusClient = require('./clients/prometheus');
+const Collector = require('./utils/collector');
+const LokiClient = require('./clients/loki');
+const TempoClient = require('./clients/tempo');
+const Http = require('./services/http');
+const {
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError
+} = require('./types');
+const { normalizeAuth } = require('./services/auth');
+
+let __legacyAuthWarned = false;
+
+/**
+ * Main client for qryn operations.
+ */
+class QrynClient {
+  /**
+   * @param {Object} config
+   * @param {string} [config.baseUrl='http://localhost:3100']
+   * @param {import('./services/auth').QrynAuth | {username:string,password:string}} [config.auth]
+   * @param {number} [config.timeout=60000]
+   * @param {Object} [config.headers={}]
+   * @param {import('./utils/retry').RetryOptions} [config.retry]
+   * @param {string} [config.defaultOrgId]
+   */
+  constructor(config) {
+    if (typeof config !== 'object' || config === null) {
+      throw new QrynError('Config must be a non-null object');
+    }
+
+    const { auth, legacy } = normalizeAuth(config.auth);
+    if (legacy && !__legacyAuthWarned) {
+      __legacyAuthWarned = true;
+      process.emitWarning(
+        "qryn-client: auth: { username, password } is deprecated; use auth: { type: 'basic', username, password }. The legacy shape will be removed in 2.0.0.",
+        'DeprecationWarning',
+        'QRYN_AUTH_LEGACY'
+      );
+    }
+
+    const baseUrl = config.baseUrl || 'http://localhost:3100';
+    const timeout = config.timeout || 60000;
+    const headers = {
+      'Content-Type': 'application/json',
+      ...config.headers
+    };
+
+    const http = new Http(baseUrl, timeout, headers, auth, {
+      retry: config.retry,
+      defaultOrgId: config.defaultOrgId
+    });
+
+    this.prom = new PrometheusClient(http);
+    this.loki = new LokiClient(http);
+    this.tempo = new TempoClient(http);
+  }
+
+  createCollector(config) { return new Collector(this, config); }
+  createStream(labels)    { return new Stream(labels); }
+  createMetric({ name, labels = {} }) { return new Metric(name, labels); }
+}
+
+module.exports = {
+  QrynClient,
+  Stream,
+  Metric,
+  Collector,
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError
+};
+```
+
+Note: the existing `Auth` class declared in this file was unused (private to the file, never instantiated). Removed.
+
+- [ ] **Step 6: Smoke-check the constructor**
+
+Run:
+
+```
+node -e "const {QrynClient} = require('./src'); new QrynClient({baseUrl:'http://x'}); console.log('ok')"
+```
+
+Expected: `ok`.
+
+Run:
+
+```
+node -e "const {QrynClient} = require('./src'); process.on('warning',w=>console.log('WARN:',w.code,w.message)); new QrynClient({baseUrl:'http://x', auth:{username:'u',password:'p'}}); setTimeout(()=>{},10);"
+```
+
+Expected: prints a line beginning `WARN: QRYN_AUTH_LEGACY ...`.
+
+- [ ] **Step 7: Run all tests to confirm no regression**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/services/auth.js tests/unit/auth.test.js src/index.js
+git commit -m "add discriminated-union auth resolver and legacy-auth deprecation shim"
+```
+
+---
+
+## Task 7: HTTP per-call options + signal/timeout error mapping
+
+This is the largest task. `Http.request` becomes the per-call options pipeline. No retry yet — that's Task 8 — so the structure stays simple.
+
+**Files:**
+- Modify: [src/services/http.js](../../../src/services/http.js)
+- Create: [tests/unit/http.test.js](../../../tests/unit/http.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/http.test.js](../../../tests/unit/http.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+const { QrynError, QrynAbortedError, QrynTimeoutError } = require('../../src/types');
+
+function mockFetch(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    return impl(url, init);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function jsonOk(body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...headers }
+  });
+}
+
+test('basic auth header is set', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({ ok: true }));
+  const http = new Http('http://q', 60000, {}, { type: 'basic', username: 'u', password: 'p' }, {}, fetchSpy);
+  await http.request('/health');
+  const auth = fetchSpy.calls[0].init.headers.Authorization;
+  assert.equal(auth, 'Basic ' + Buffer.from('u:p').toString('base64'));
+});
+
+test('bearer thunk auth header is awaited', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, { type: 'bearer', token: async () => 'fresh' }, {}, fetchSpy);
+  await http.request('/health');
+  assert.equal(fetchSpy.calls[0].init.headers.Authorization, 'Bearer fresh');
+});
+
+test('defaultOrgId becomes X-Scope-OrgID', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, undefined, { defaultOrgId: 'tenant-a' }, fetchSpy);
+  await http.request('/health');
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-a');
+});
+
+test('per-call orgId overrides defaultOrgId', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, undefined, { defaultOrgId: 'tenant-a' }, fetchSpy);
+  await http.request('/health', { orgId: 'tenant-b' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-b');
+});
+
+test('per-call timeoutMs maps an AbortError to QrynTimeoutError', async () => {
+  const fetchSpy = mockFetch(async (_url, init) => {
+    await new Promise((resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      }, { once: true });
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  await assert.rejects(
+    () => http.request('/slow', { timeoutMs: 5 }),
+    (err) => err instanceof QrynTimeoutError && typeof err.elapsedMs === 'number'
+  );
+});
+
+test('caller AbortSignal maps to QrynAbortedError', async () => {
+  const fetchSpy = mockFetch(async (_url, init) => {
+    await new Promise((resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      }, { once: true });
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  const ac = new AbortController();
+  const reason = new Error('user-cancel');
+  setTimeout(() => ac.abort(reason), 5);
+  await assert.rejects(
+    () => http.request('/slow', { signal: ac.signal, timeoutMs: 60000 }),
+    (err) => err instanceof QrynAbortedError && err.reason === reason
+  );
+});
+
+test('non-2xx still throws QrynError', async () => {
+  const fetchSpy = mockFetch(() => new Response(JSON.stringify({ msg: 'bad' }), {
+    status: 400,
+    headers: { 'content-type': 'application/json' }
+  }));
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  await assert.rejects(
+    () => http.request('/x'),
+    (err) => err instanceof QrynError && err.statusCode === 400
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `Http` constructor signature has changed; tests blow up on the extra args.
+
+- [ ] **Step 3: Reimplement `Http`**
+
+Replace the entire content of [src/services/http.js](../../../src/services/http.js):
+
+```js
+'use strict';
+
+const { URL } = require('url');
+const {
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
+  QrynResponse
+} = require('../types');
+const { resolveAuthHeaders } = require('./auth');
+const { anySignal } = require('../utils/abort');
+
+/**
+ * Handles HTTP requests for QrynClient.
+ */
+class Http {
+  /**
+   * @param {string} baseUrl
+   * @param {number} timeout - default per-request timeout in ms.
+   * @param {Object} headers - default headers, merged before auth.
+   * @param {import('./auth').QrynAuth|undefined} auth
+   * @param {Object} [opts]
+   * @param {import('../utils/retry').RetryOptions} [opts.retry]
+   * @param {string} [opts.defaultOrgId]
+   * @param {typeof globalThis.fetch} [fetchImpl] - injected for testing.
+   */
+  constructor(baseUrl, timeout, headers, auth, opts = {}, fetchImpl = globalThis.fetch) {
+    this.baseUrl = new URL(baseUrl);
+    this.timeout = timeout;
+    this.headers = headers;
+    this.auth = auth;
+    this.defaultRetry = opts.retry;
+    this.defaultOrgId = opts.defaultOrgId;
+    this.fetchImpl = fetchImpl;
+  }
+
+  /**
+   * @param {string} path
+   * @param {Object} [options]
+   * @param {string} [options.method]
+   * @param {Object} [options.headers]
+   * @param {*} [options.body]
+   * @param {AbortSignal} [options.signal]
+   * @param {number} [options.timeoutMs]
+   * @param {string} [options.orgId]
+   * @returns {Promise<QrynResponse>}
+   */
+  async request(path, options = {}) {
+    const url = new URL(path, this.baseUrl);
+    const effectiveTimeout = options.timeoutMs ?? this.timeout;
+
+    const authHeaders = await resolveAuthHeaders(this.auth);
+    const orgId = options.orgId ?? this.defaultOrgId;
+
+    const headers = {
+      ...this.headers,
+      ...options.headers,
+      ...authHeaders
+    };
+    if (orgId) headers['X-Scope-OrgID'] = orgId;
+
+    const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
+    const signal = options.signal
+      ? anySignal([options.signal, timeoutSignal])
+      : timeoutSignal;
+
+    const startedAt = Date.now();
+    let response;
+    try {
+      response = await this.fetchImpl(url.toString(), {
+        method: options.method,
+        headers,
+        body: options.body,
+        signal
+      });
+    } catch (error) {
+      if (error && error.name === 'AbortError') {
+        if (options.signal && options.signal.aborted) {
+          throw new QrynAbortedError(
+            'Request aborted by caller',
+            options.signal.reason,
+            path
+          );
+        }
+        throw new QrynTimeoutError(
+          `Request timed out after ${effectiveTimeout}ms`,
+          Date.now() - startedAt,
+          path
+        );
+      }
+      throw new QrynError(
+        `Request failed: ${error.message} ${error?.cause?.message ?? ''}`.trim(),
+        400,
+        error.cause,
+        path
+      );
+    }
+
+    let body = {};
+    const ct = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+    if (response.status !== 204) {
+      if (ct.includes('application/json')) {
+        body = await response.json().catch(() => ({}));
+      } else if (ct) {
+        const text = await response.text().catch(() => '');
+        body = text || {};
+      }
+    }
+
+    if (!response.ok) {
+      throw new QrynError(`HTTP error! status: ${response.status}`, response.status, body, path);
+    }
+
+    return new QrynResponse(body, response.status, response.headers, path);
+  }
+}
+
+module.exports = Http;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `http.test.js` tests pass; previous tests still green.
+
+- [ ] **Step 5: Smoke-check the public surface**
+
+Run: `node -e "require('./src')"`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/http.js tests/unit/http.test.js
+git commit -m "rebuild Http around per-call options, async auth, and typed abort/timeout errors"
+```
+
+---
+
+## Task 8: HTTP retry policy
+
+Layer the retry loop on top of the per-call pipeline from Task 7. Each attempt gets the full `timeoutMs` budget. Caller `AbortSignal` short-circuits the loop.
+
+**Files:**
+- Modify: [src/services/http.js](../../../src/services/http.js)
+- Modify: [tests/unit/http.test.js](../../../tests/unit/http.test.js)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to [tests/unit/http.test.js](../../../tests/unit/http.test.js):
+
+```js
+test('retry: 503 retried up to attempts then fails', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    return new Response('boom', { status: 503 });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await assert.rejects(() => http.request('/x'));
+  assert.equal(calls, 3);
+});
+
+test('retry: 200 returns immediately, no extra calls', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => { calls++; return jsonOk({ ok: true }); });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await http.request('/x');
+  assert.equal(calls, 1);
+});
+
+test('retry: 400 not retried', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    return new Response(JSON.stringify({ err: 'bad' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await assert.rejects(() => http.request('/x'));
+  assert.equal(calls, 1);
+});
+
+test('retry: 429 honors Retry-After header', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    if (calls === 1) {
+      return new Response('limit', { status: 429, headers: { 'Retry-After': '0' } });
+    }
+    return jsonOk({ ok: true });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 5000, maxDelayMs: 5000 }
+  }, fetchSpy);
+  const t0 = Date.now();
+  await http.request('/x');
+  const elapsed = Date.now() - t0;
+  // baseDelayMs=5000 would force a long wait; Retry-After:0 must short-circuit it.
+  assert.ok(elapsed < 1000, `expected <1s, got ${elapsed}ms`);
+  assert.equal(calls, 2);
+});
+
+test('retry: caller-aborted signal stops the loop', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(async (_url, init) => {
+    calls++;
+    return new Response('boom', { status: 503 });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 5, baseDelayMs: 50, maxDelayMs: 50 }
+  }, fetchSpy);
+  const ac = new AbortController();
+  setTimeout(() => ac.abort(new Error('cancel')), 20);
+  await assert.rejects(
+    () => http.request('/x', { signal: ac.signal }),
+    (err) => err instanceof QrynAbortedError
+  );
+  assert.ok(calls < 5, `expected loop to short-circuit, got ${calls} calls`);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: the new tests fail (no retry loop yet).
+
+- [ ] **Step 3: Add the retry loop to `Http.request`**
+
+Edit [src/services/http.js](../../../src/services/http.js). Add imports:
+
+```js
+const {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+} = require('../utils/retry');
+```
+
+Add a private helper method below `request` and refactor `request` to delegate to it. The new shape of the class:
+
+```js
+async request(path, options = {}) {
+  const retryOpts = { ...DEFAULT_RETRY, ...this.defaultRetry, ...options.retry };
+  const attempts = Math.max(1, retryOpts.attempts);
+
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (options.signal && options.signal.aborted) {
+      throw new QrynAbortedError('Request aborted by caller', options.signal.reason, path);
+    }
+    try {
+      return await this.#singleRequest(path, options);
+    } catch (error) {
+      lastError = error;
+
+      // Caller abort: never retry.
+      if (error instanceof QrynAbortedError) throw error;
+
+      const isLast = attempt === attempts;
+      if (isLast) throw error;
+
+      let delayMs;
+      if (error instanceof QrynError && typeof error.statusCode === 'number') {
+        const retryAfterFromCustom = retryOpts.retryOn
+          ? retryOpts.retryOn(error.statusCode, attempt)
+          : isRetryableStatus(error.statusCode);
+        if (!retryAfterFromCustom) throw error;
+
+        const headerVal = error.cause && error.cause.headers
+          ? error.cause.headers.get && error.cause.headers.get('retry-after')
+          : null;
+        const fromHeader = error.statusCode === 429 ? parseRetryAfter(headerVal) : null;
+        delayMs = fromHeader != null ? fromHeader : computeBackoff(attempt, retryOpts);
+      } else if (isRetryableNetworkError(error) || (error instanceof QrynError && error.cause && isRetryableNetworkError(error.cause))) {
+        delayMs = computeBackoff(attempt, retryOpts);
+      } else {
+        throw error;
+      }
+
+      await this.#sleep(delayMs, options.signal);
+    }
+  }
+  throw lastError;
+}
+
+async #singleRequest(path, options) {
+  const url = new URL(path, this.baseUrl);
+  const effectiveTimeout = options.timeoutMs ?? this.timeout;
+
+  const authHeaders = await resolveAuthHeaders(this.auth);
+  const orgId = options.orgId ?? this.defaultOrgId;
+
+  const headers = { ...this.headers, ...options.headers, ...authHeaders };
+  if (orgId) headers['X-Scope-OrgID'] = orgId;
+
+  const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
+  const signal = options.signal ? anySignal([options.signal, timeoutSignal]) : timeoutSignal;
+
+  const startedAt = Date.now();
+  let response;
+  try {
+    response = await this.fetchImpl(url.toString(), {
+      method: options.method,
+      headers,
+      body: options.body,
+      signal
+    });
+  } catch (error) {
+    if (error && error.name === 'AbortError') {
+      if (options.signal && options.signal.aborted) {
+        throw new QrynAbortedError('Request aborted by caller', options.signal.reason, path);
+      }
+      throw new QrynTimeoutError(
+        `Request timed out after ${effectiveTimeout}ms`,
+        Date.now() - startedAt,
+        path
+      );
+    }
+    throw new QrynError(
+      `Request failed: ${error.message} ${error?.cause?.message ?? ''}`.trim(),
+      400,
+      error.cause,
+      path
+    );
+  }
+
+  let body = {};
+  const ct = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+  if (response.status !== 204) {
+    if (ct.includes('application/json')) {
+      body = await response.json().catch(() => ({}));
+    } else if (ct) {
+      const text = await response.text().catch(() => '');
+      body = text || {};
+    }
+  }
+
+  if (!response.ok) {
+    const cause = { headers: response.headers, body };
+    throw new QrynError(`HTTP error! status: ${response.status}`, response.status, cause, path);
+  }
+
+  return new QrynResponse(body, response.status, response.headers, path);
+}
+
+#sleep(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) return resolve();
+    const timer = setTimeout(resolve, ms);
+    if (signal) {
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new QrynAbortedError('Request aborted by caller', signal.reason));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+```
+
+Note that `QrynError.cause` for non-2xx responses now carries `{ headers, body }` so the retry loop can read `Retry-After`. The previous shape of `QrynError.cause` was the raw response body; this is a near-internal detail (no documented consumer reads `.cause`), but document it in the error JSDoc if you touch [qrynError.js](../../../src/types/qrynError.js).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `http.test.js` tests pass.
+
+- [ ] **Step 5: Smoke-check the existing client paths**
+
+Run: `node -e "const {QrynClient} = require('./src'); new QrynClient({baseUrl:'http://x'}); console.log('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/http.js tests/unit/http.test.js
+git commit -m "add retry loop with backoff, jitter and Retry-After"
+```
+
+---
+
+## Task 9: Plumb `opts` through `PromReader` and existing pushes
+
+The push paths and the existing prom reader must accept the new per-call opts (`signal`, `timeoutMs`, `retry`, `orgId`). No behavioral change for callers who don't pass them.
+
+**Files:**
+- Modify: [src/clients/prometheus.js](../../../src/clients/prometheus.js)
+- Modify: [src/clients/loki.js](../../../src/clients/loki.js)
+
+- [ ] **Step 1: Update `PromReader` (the `Read` class) methods**
+
+Edit [src/clients/prometheus.js](../../../src/clients/prometheus.js) `Read` class. Each method accepts a trailing `opts` arg and threads it through. Specifically:
+
+```js
+async query(query, opts = {}) {
+  return this.service.request('/api/v1/query', {
+    method: 'POST',
+    headers: this.headers(),
+    body: { query },
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus query failed: ${error.message}`, error.statusCode);
+  });
+}
+
+async queryRange(query, start, end, step, opts = {}) {
+  return this.service.request('/api/v1/query_range', {
+    method: 'POST',
+    headers: this.headers(),
+    body: new URLSearchParams({ query, start, end, step }),
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus query range failed: ${error.message}`, error.statusCode);
+  });
+}
+
+async labels(opts = {}) {
+  return this.service.request('/api/v1/labels', {
+    method: 'GET',
+    headers: this.headers(),
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus labels retrieval failed: ${error.message}`, error.statusCode);
+  });
+}
+
+async labelValues(labelName, opts = {}) {
+  return this.service.request(`/api/v1/label/${labelName}/values`, {
+    method: 'GET',
+    headers: this.headers(),
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus label values retrieval failed: ${error.message}`, error.statusCode);
+  });
+}
+
+async series(match, start, end, opts = {}) {
+  let params = new URLSearchParams({ start, end });
+  if (!match) throw new QrynError('match parameter is required');
+  if (typeof match === 'string') match = [match];
+  match.forEach(m => params.append('match[]', m));
+
+  return this.service.request('/api/v1/series', {
+    method: 'POST',
+    headers: this.headers(),
+    body: params,
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus series retrieval failed: ${error.message}`, error.statusCode);
+  });
+}
+
+async rules(opts = {}) {
+  return this.service.request('/api/v1/rules', {
+    method: 'GET',
+    headers: this.headers(),
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    retry: opts.retry,
+    orgId: opts.orgId ?? this.options?.orgId
+  }).catch(error => {
+    if (error instanceof QrynError) throw error;
+    throw new QrynError(`Prometheus rules retrieval failed: ${error.message}`, error.statusCode);
+  });
+}
+```
+
+(Update each method's JSDoc to add `@param {ReadOpts} [opts]`.)
+
+- [ ] **Step 2: Update `Prometheus.push` to forward `opts.signal`/`opts.timeoutMs`/`opts.retry`**
+
+In the same file, in the `Prometheus` class `push` method, replace the `service.request(...)` call:
+
+```js
+return this.service.request('/api/v1/prom/remote/write', {
+  method: 'POST',
+  headers: this.headers(options),
+  body: compressedBuffer,
+  signal: options && options.signal,
+  timeoutMs: options && options.timeoutMs,
+  retry: options && options.retry
+}).then(res => {
+  metrics.forEach(metric => metric.confirm());
+  return res;
+}).catch(error => {
+  metrics.forEach(metric => metric.undo());
+  if (error instanceof QrynError) throw error;
+  throw new QrynError(`Prometheus Remote Write push failed: ${error.message}`, error.statusCode);
+});
+```
+
+(`headers(options)` already pulls `orgId` out and sets `X-Scope-OrgID`; do not also pass `orgId` to `request`, or it'll be set twice — same outcome but redundant.)
+
+- [ ] **Step 3: Update `Loki.push` similarly**
+
+In [src/clients/loki.js](../../../src/clients/loki.js), update the `service.request` call inside `push`:
+
+```js
+const response = await this.service.request('/loki/api/v1/push', {
+  method: 'POST',
+  headers,
+  body: JSON.stringify(payload),
+  signal: options.signal,
+  timeoutMs: options.timeoutMs,
+  retry: options.retry
+});
+```
+
+- [ ] **Step 4: Smoke-check the require graph**
+
+Run: `node -e "require('./src')"`
+Expected: exits 0.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npm test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clients/prometheus.js src/clients/loki.js
+git commit -m "plumb per-call opts (signal, timeoutMs, retry) through prom and loki write paths"
+```
+
+---
+
+## Task 10: `LokiReader` — new client
+
+**Files:**
+- Create: [src/clients/loki-read.js](../../../src/clients/loki-read.js)
+- Modify: [src/clients/loki.js](../../../src/clients/loki.js)
+- Create: [tests/unit/loki-read.test.js](../../../tests/unit/loki-read.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/loki-read.test.js](../../../tests/unit/loki-read.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+
+function jsonOk(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+function fetchCapture(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return impl ? impl(url, init) : jsonOk({ status: 'success', data: {} });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeClient(fetchSpy) {
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  const Loki = require('../../src/clients/loki');
+  return new Loki(http).createReader({ orgId: 'tenant-a' });
+}
+
+test('query: GET /loki/api/v1/query with normalized time', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.query('{job="x"} |= `boom`', new Date(1700000000000));
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /\/loki\/api\/v1\/query\?/);
+  assert.match(call.url, /query=%7Bjob%3D%22x%22%7D/);
+  assert.match(call.url, /time=1700000000000000000/);
+  assert.equal(call.init.method, 'GET');
+  assert.equal(call.init.headers['X-Scope-OrgID'], 'tenant-a');
+});
+
+test('queryRange: passes step, limit, direction', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.queryRange('{job="x"}', 1700000000, 1700003600, '15s', 100, 'backward');
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /step=15s/);
+  assert.match(call.url, /limit=100/);
+  assert.match(call.url, /direction=backward/);
+  assert.match(call.url, /start=1700000000000000000/);
+  assert.match(call.url, /end=1700003600000000000/);
+});
+
+test('labels: omits start/end when not given', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labels();
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /\/loki\/api\/v1\/labels(\?|$)/);
+  assert.doesNotMatch(call.url, /start=/);
+  assert.doesNotMatch(call.url, /end=/);
+});
+
+test('labelValues: encodes label name', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labelValues('job');
+  assert.match(fetchSpy.calls[0].url, /\/loki\/api\/v1\/label\/job\/values/);
+});
+
+test('series: repeated match[] params', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.series(['{a="1"}', '{b="2"}'], 1700000000, 1700003600);
+  const call = fetchSpy.calls[0];
+  // URLSearchParams encodes both as repeated match%5B%5D=
+  assert.match(call.url, /match%5B%5D=%7Ba%3D%221%22%7D/);
+  assert.match(call.url, /match%5B%5D=%7Bb%3D%222%22%7D/);
+});
+
+test('per-call opts.orgId overrides reader-level orgId', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labels(undefined, undefined, { orgId: 'tenant-b' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-b');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `loki-read` module not found and no `createReader` on Loki.
+
+- [ ] **Step 3: Implement `LokiReader`**
+
+Create [src/clients/loki-read.js](../../../src/clients/loki-read.js):
+
+```js
+'use strict';
+
+const { QrynError } = require('../types');
+const { toNanos } = require('../utils/time');
+
+/**
+ * Loki read client — LogQL queries, labels, label values, series.
+ * @see https://grafana.com/docs/loki/latest/reference/loki-http-api/
+ */
+class LokiReader {
+  /**
+   * @param {import('../services/http')} service
+   * @param {{ orgId?: string }} [options]
+   */
+  constructor(service, options = {}) {
+    this.service = service;
+    this.options = options;
+  }
+
+  /**
+   * Instant LogQL query.
+   * @param {string} query
+   * @param {Date|number|string} [time]
+   * @param {import('./read-opts').ReadOpts} [opts]
+   */
+  async query(query, time, opts = {}) {
+    const params = new URLSearchParams();
+    params.set('query', query);
+    if (time !== undefined) params.set('time', toNanos(time));
+    return this.#get('/loki/api/v1/query', params, opts, 'query');
+  }
+
+  /**
+   * Range LogQL query.
+   */
+  async queryRange(query, start, end, step, limit, direction, opts = {}) {
+    const params = new URLSearchParams();
+    params.set('query', query);
+    params.set('start', toNanos(start));
+    params.set('end', toNanos(end));
+    if (step !== undefined) params.set('step', String(step));
+    if (limit !== undefined) params.set('limit', String(limit));
+    if (direction !== undefined) params.set('direction', String(direction));
+    return this.#get('/loki/api/v1/query_range', params, opts, 'queryRange');
+  }
+
+  /**
+   * List label names.
+   */
+  async labels(start, end, opts = {}) {
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    return this.#get('/loki/api/v1/labels', params, opts, 'labels');
+  }
+
+  /**
+   * Values for a single label.
+   */
+  async labelValues(label, start, end, match, opts = {}) {
+    if (!label) throw new QrynError('label parameter is required');
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    if (match !== undefined) params.set('query', String(match));
+    return this.#get(
+      `/loki/api/v1/label/${encodeURIComponent(label)}/values`,
+      params,
+      opts,
+      'labelValues'
+    );
+  }
+
+  /**
+   * Series matching one or more matchers.
+   */
+  async series(matchers, start, end, opts = {}) {
+    if (!matchers) throw new QrynError('matchers parameter is required');
+    const list = Array.isArray(matchers) ? matchers : [matchers];
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    list.forEach(m => params.append('match[]', m));
+    return this.#get('/loki/api/v1/series', params, opts, 'series');
+  }
+
+  /**
+   * @param {string} basePath
+   * @param {URLSearchParams} params
+   * @param {Object} opts
+   * @param {string} verb - method label for error messages
+   */
+  async #get(basePath, params, opts, verb) {
+    const qs = params.toString();
+    const path = qs ? `${basePath}?${qs}` : basePath;
+    return this.service.request(path, {
+      method: 'GET',
+      headers: this.#headers(opts),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options.orgId
+    }).catch(error => {
+      if (error instanceof QrynError) throw error;
+      throw new QrynError(`Loki ${verb} failed: ${error.message}`, error.statusCode);
+    });
+  }
+
+  #headers(_opts) {
+    return {
+      'Accept': 'application/json'
+    };
+  }
+}
+
+module.exports = LokiReader;
+```
+
+- [ ] **Step 4: Add `createReader` to `Loki`**
+
+Edit [src/clients/loki.js](../../../src/clients/loki.js). Add inside the `Loki` class:
+
+```js
+/**
+ * Create a LokiReader bound to this client's service.
+ * @param {{ orgId?: string }} [options]
+ * @returns {import('./loki-read')}
+ */
+createReader(options = {}) {
+  const LokiReader = require('./loki-read');
+  return new LokiReader(this.service, options);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `loki-read.test.js` tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clients/loki-read.js src/clients/loki.js tests/unit/loki-read.test.js
+git commit -m "add LokiReader (LogQL query/queryRange/labels/labelValues/series)"
+```
+
+---
+
+## Task 11: Tempo alignment — `searchTags`, `searchTagValues`, `getTrace`, opts plumbing
+
+**Files:**
+- Modify: [src/clients/tempo.js](../../../src/clients/tempo.js)
+- Create: [tests/unit/tempo.test.js](../../../tests/unit/tempo.test.js)
+
+- [ ] **Step 1: Write the failing test**
+
+Create [tests/unit/tempo.test.js](../../../tests/unit/tempo.test.js):
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+const TempoClient = require('../../src/clients/tempo');
+
+function jsonOk(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+function fetchCapture() {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return jsonOk({ traces: [] });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function client(fetchSpy) {
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  return new TempoClient(http);
+}
+
+test('searchTags: scope query param', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags('span');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tags\?scope=span$/);
+});
+
+test('searchTags: scope omitted when not given', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags();
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tags(\?)?$/);
+});
+
+test('searchTagValues: v1 path encodes tag', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTagValues('service.name');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tag\/service\.name\/values/);
+});
+
+test('getTrace: aliases getTraceSpansJson path', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.getTrace('abc123');
+  assert.match(fetchSpy.calls[0].url, /\/api\/traces\/abc123\/json/);
+});
+
+test('search: SearchOpts object becomes query string with q', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.search({ q: '{ duration > 1s }', limit: 5, spss: 10 });
+  const url = fetchSpy.calls[0].url;
+  assert.match(url, /q=%7B\+duration\+%3E\+1s\+%7D/);
+  assert.match(url, /limit=5/);
+  assert.match(url, /spss=10/);
+});
+
+test('search: string input preserved (back-compat)', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.search('q=foo');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\?q=foo$/);
+});
+
+test('opts.orgId sets X-Scope-OrgID', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags('span', { orgId: 'tenant-a' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-a');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: failures on `searchTags`/`searchTagValues`/`getTrace` (don't exist yet) and on the `search({...})` object form.
+
+- [ ] **Step 3: Update `TempoClient`**
+
+Replace the entire content of [src/clients/tempo.js](../../../src/clients/tempo.js):
+
+```js
+'use strict';
+
+const { QrynError } = require('../types');
+
+/**
+ * Tempo client — read-side access to traces stored in qryn.
+ * @see https://grafana.com/docs/tempo/latest/api_docs/
+ */
+class TempoClient {
+  /**
+   * @param {import('../services/http')} service
+   */
+  constructor(service) {
+    this.service = service;
+  }
+
+  /**
+   * TraceQL search.
+   * The first argument has three accepted shapes:
+   *   - string: treated as a raw query string fragment (back-compat).
+   *   - URLSearchParams: serialized directly (back-compat).
+   *   - SearchOpts object: { q, start, end, limit, spss } — built into the query string.
+   *
+   * @param {string|URLSearchParams|{q:string,start?:Date|number,end?:Date|number,limit?:number,spss?:number}} [searchParams]
+   * @param {Object} [options]
+   * @param {string} [options.orgId]
+   * @param {AbortSignal} [options.signal]
+   * @param {number} [options.timeoutMs]
+   * @param {import('../utils/retry').RetryOptions} [options.retry]
+   */
+  async search(searchParams, options = {}) {
+    const qs = this.#searchParamsToString(searchParams);
+    return this.#get(`/api/search${qs ? `?${qs}` : ''}`, options, 'search');
+  }
+
+  /**
+   * GET /api/search/tags
+   * @param {'span'|'resource'|'intrinsic'} [scope]
+   * @param {Object} [options] - opts.signal/timeoutMs/retry/orgId
+   */
+  async searchTags(scope, options = {}) {
+    const path = scope ? `/api/search/tags?scope=${encodeURIComponent(scope)}` : '/api/search/tags';
+    return this.#get(path, options, 'searchTags');
+  }
+
+  /**
+   * GET /api/search/tag/{tag}/values  (v1)
+   */
+  async searchTagValues(tagName, options = {}) {
+    if (!tagName) throw new QrynError('tagName is required');
+    return this.#get(
+      `/api/search/tag/${encodeURIComponent(tagName)}/values`,
+      options,
+      'searchTagValues'
+    );
+  }
+
+  /**
+   * GET /api/v2/search/tag/{tagName}/values
+   */
+  async searchTagValuesV2(tagName, searchParams, options = {}) {
+    const qs = this.#searchParamsToString(searchParams);
+    const path = `/api/v2/search/tag/${encodeURIComponent(tagName)}/values${qs ? `?${qs}` : ''}`;
+    return this.#get(path, options, 'searchTagValuesV2');
+  }
+
+  /**
+   * GET /api/traces/{traceId}/json
+   * Existing method — kept for back-compat.
+   */
+  async getTraceSpansJson(traceID, options = {}) {
+    return this.#get(`/api/traces/${encodeURIComponent(traceID)}/json`, options, 'getTraceSpansJson');
+  }
+
+  /**
+   * Spec-aligned alias of getTraceSpansJson.
+   */
+  async getTrace(traceID, options = {}) {
+    return this.getTraceSpansJson(traceID, options);
+  }
+
+  // -- helpers --
+
+  #searchParamsToString(input) {
+    if (input == null) return '';
+    if (typeof input === 'string') return input;
+    if (input instanceof URLSearchParams) return input.toString();
+    if (typeof input === 'object') {
+      const params = new URLSearchParams();
+      if (input.q !== undefined)     params.set('q', input.q);
+      if (input.start !== undefined) params.set('start', String(input.start instanceof Date ? input.start.getTime() : input.start));
+      if (input.end !== undefined)   params.set('end',   String(input.end   instanceof Date ? input.end.getTime()   : input.end));
+      if (input.limit !== undefined) params.set('limit', String(input.limit));
+      if (input.spss !== undefined)  params.set('spss',  String(input.spss));
+      return params.toString();
+    }
+    return String(input);
+  }
+
+  #headers(options) {
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    };
+    if (options.orgId) headers['X-Scope-OrgID'] = options.orgId;
+    return headers;
+  }
+
+  async #get(path, options, verb) {
+    return this.service.request(path, {
+      method: 'GET',
+      headers: this.#headers(options),
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+      retry: options.retry,
+      orgId: options.orgId
+    }).catch(error => {
+      if (error instanceof QrynError) throw error;
+      throw new QrynError(`Tempo ${verb} failed: ${error.message}`, error.statusCode);
+    });
+  }
+}
+
+module.exports = TempoClient;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: all `tempo.test.js` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/clients/tempo.js tests/unit/tempo.test.js
+git commit -m "align Tempo client with v1.1 spec (searchTags, searchTagValues, getTrace, opts)"
+```
+
+---
+
+## Task 12: TypeScript declaration emission + hand-written `index.d.ts`
+
+**Files:**
+- Create: [tsconfig.json](../../../tsconfig.json)
+- Create: [tsconfig.types.json](../../../tsconfig.types.json)
+- Create: [index.d.ts](../../../index.d.ts)
+- Modify: [package.json](../../../package.json)
+- Modify: [.gitignore](../../../.gitignore) (add `dist/`)
+
+- [ ] **Step 1: Add `typescript` as a devDependency**
+
+Run: `npm install --save-dev typescript@^5.4.0`
+Expected: dep installs cleanly.
+
+- [ ] **Step 2: Create `tsconfig.json` (consumer-smoke)**
+
+Create [tsconfig.json](../../../tsconfig.json):
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["index.d.ts", "tests/types/**/*"]
+}
+```
+
+- [ ] **Step 3: Create `tsconfig.types.json` (declaration emit)**
+
+Create [tsconfig.types.json](../../../tsconfig.types.json):
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "outDir": "dist/types",
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}
+```
+
+- [ ] **Step 4: Create the hand-written `index.d.ts`**
+
+Create [index.d.ts](../../../index.d.ts):
+
+```ts
+// Hand-written TypeScript surface for qryn-client.
+// Augments declarations generated from JSDoc with named response types and
+// generic QrynResponse<T>. The runtime contract is the JS source in src/.
+
+import type { Agent } from 'http';
+
+// -- core errors --
+
+export class QrynError extends Error {
+  statusCode: number | null;
+  cause?: unknown;
+  path?: string;
+  constructor(message: string, statusCode?: number | null, cause?: unknown, path?: string);
+}
+
+export class QrynAbortedError extends QrynError {
+  reason?: unknown;
+}
+
+export class QrynTimeoutError extends QrynError {
+  elapsedMs: number;
+}
+
+// -- response wrapper --
+
+export class QrynResponse<T = unknown> {
+  response: T;
+  status: number;
+  headers: Headers | Record<string, string>;
+  path: string;
+  isSuccess(): boolean;
+  getData(): T;
+}
+
+// -- auth --
+
+export interface BasicAuth { type: 'basic'; username: string; password: string; }
+export interface BearerAuth { type: 'bearer'; token: string | (() => Promise<string>); }
+export interface CustomAuth {
+  type: 'custom';
+  headers: Record<string, string> | (() => Promise<Record<string, string>>);
+}
+export type QrynAuth = BasicAuth | BearerAuth | CustomAuth;
+
+// -- retry / read opts --
+
+export interface RetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  retryOn?: (status: number, attempt: number) => boolean;
+}
+
+export interface ReadOpts {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  retry?: RetryOptions;
+  orgId?: string;
+}
+
+// -- client config --
+
+export interface QrynClientOptions {
+  baseUrl?: string;
+  auth?: QrynAuth | { username: string; password: string };  // legacy shape accepted (deprecated)
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry?: RetryOptions;
+  defaultOrgId?: string;
+  agent?: Agent;
+}
+
+// -- Loki --
+
+export interface Stream {
+  addEntry(timestamp: number | string | Date, line: string): void;
+}
+
+export interface LokiPushOptions extends ReadOpts {
+  async?: boolean | string;
+  fpLimit?: number;
+  ttlDays?: number;
+}
+
+export interface LokiInstantResponse {
+  status: 'success' | string;
+  data: { resultType: string; result: unknown[] };
+}
+export interface LokiRangeResponse extends LokiInstantResponse {}
+export interface SeriesResponse {
+  status: 'success' | string;
+  data: Array<Record<string, string>>;
+}
+
+export class LokiReader {
+  query(query: string, time?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<LokiInstantResponse>>;
+  queryRange(
+    query: string,
+    start: Date | number | string,
+    end: Date | number | string,
+    step?: string,
+    limit?: number,
+    direction?: 'forward' | 'backward',
+    opts?: ReadOpts
+  ): Promise<QrynResponse<LokiRangeResponse>>;
+  labels(start?: Date | number | string, end?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<{ status: string; data: string[] }>>;
+  labelValues(label: string, start?: Date | number | string, end?: Date | number | string, match?: string, opts?: ReadOpts): Promise<QrynResponse<{ status: string; data: string[] }>>;
+  series(matchers: string[] | string, start?: Date | number | string, end?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<SeriesResponse>>;
+}
+
+export class Loki {
+  push(streams: Stream[], options?: LokiPushOptions): Promise<QrynResponse<unknown>>;
+  createReader(options?: { orgId?: string }): LokiReader;
+}
+
+// -- Prometheus --
+
+export interface Metric {
+  addSample(value: number, timestamp?: number): void;
+}
+
+export interface PromPushOptions extends ReadOpts {
+  async?: boolean | string;
+  fpLimit?: number;
+  ttlDays?: number;
+}
+
+export class PromReader {
+  query(query: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  queryRange(query: string, start: number, end: number, step: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  labels(opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  labelValues(labelName: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  series(match: string | string[], start: number, end: number, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  rules(opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+}
+
+export class Prometheus {
+  push(metrics: Metric[], options?: PromPushOptions): Promise<QrynResponse<unknown> | undefined>;
+  createReader(options?: { orgId?: string }): PromReader;
+}
+
+// -- Tempo --
+
+export interface SearchOpts {
+  q: string;
+  start?: Date | number;
+  end?: Date | number;
+  limit?: number;
+  spss?: number;
+}
+
+export interface TempoSearchResponse {
+  traces?: Array<{
+    traceID: string;
+    rootServiceName?: string;
+    rootTraceName?: string;
+    durationMs?: number;
+    startTimeUnixNano?: string;
+    spanCount?: number;
+  }>;
+}
+
+export interface TraceResponse { batches: unknown[]; }
+
+export class TempoClient {
+  search(searchParams?: string | URLSearchParams | SearchOpts, options?: ReadOpts): Promise<QrynResponse<TempoSearchResponse>>;
+  searchTags(scope?: 'span' | 'resource' | 'intrinsic', options?: ReadOpts): Promise<QrynResponse<{ tagNames?: string[] }>>;
+  searchTagValues(tagName: string, options?: ReadOpts): Promise<QrynResponse<{ tagValues?: string[] }>>;
+  searchTagValuesV2(tagName: string, searchParams?: string | URLSearchParams, options?: ReadOpts): Promise<QrynResponse<unknown>>;
+  getTrace(traceId: string, options?: ReadOpts): Promise<QrynResponse<TraceResponse>>;
+  getTraceSpansJson(traceId: string, options?: ReadOpts): Promise<QrynResponse<TraceResponse>>;
+}
+
+// -- Collector --
+
+export interface CollectorOptions {
+  maxBulkSize?: number;
+  maxTimeout?: number;
+}
+
+export class Collector {
+  pushStream(stream: Stream): void;
+  pushMetric(metric: Metric): void;
+  flush(): Promise<void>;
+}
+
+// -- Client --
+
+export class QrynClient {
+  constructor(config: QrynClientOptions);
+  loki: Loki;
+  prom: Prometheus;
+  tempo: TempoClient;
+
+  createCollector(config?: CollectorOptions): Collector;
+  createStream(labels: Record<string, string>): Stream;
+  createMetric(input: { name: string; labels?: Record<string, string> }): Metric;
+}
+```
+
+- [ ] **Step 5: Update package.json**
+
+Edit [package.json](../../../package.json):
+
+```json
+{
+  "main": "src/index.js",
+  "types": "index.d.ts",
+  "files": ["src", "index.d.ts", "dist/types"],
+  "scripts": {
+    "test": "node --test tests/unit/",
+    "test:types": "tsc -p tsconfig.json",
+    "build:types": "tsc -p tsconfig.types.json"
+  }
+}
+```
+
+(Keep all existing fields. Merge — do not overwrite — `scripts`. The `test` script is unchanged from Task 1.)
+
+- [ ] **Step 6: Update `.gitignore`**
+
+Add to [.gitignore](../../../.gitignore):
+
+```
+dist/
+node_modules/
+```
+
+(`node_modules/` may already be present; ensure both are.)
+
+- [ ] **Step 7: Verify type emit**
+
+Run: `npm run build:types`
+Expected: exits 0; populates `dist/types/`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tsconfig.json tsconfig.types.json index.d.ts package.json package-lock.json .gitignore
+git commit -m "add hand-written index.d.ts and tsc declaration pipeline"
+```
+
+(If `package-lock.json` is in `.gitignore` and not tracked, `git add` will warn — that's fine, just don't include it. Per [AGENTS.md §11](../../../AGENTS.md), `package-lock.json` is intentionally not tracked.)
+
+---
+
+## Task 13: Consumer type-smoke
+
+**Files:**
+- Create: [tests/types/consumer-smoke.ts](../../../tests/types/consumer-smoke.ts)
+
+- [ ] **Step 1: Write the consumer smoke**
+
+Create [tests/types/consumer-smoke.ts](../../../tests/types/consumer-smoke.ts):
+
+```ts
+import {
+  QrynClient,
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
+  type QrynAuth,
+  type RetryOptions,
+  type ReadOpts,
+  type SearchOpts,
+} from 'qryn-client';
+
+// 1. Constructor with each auth shape.
+const basic = new QrynClient({
+  baseUrl: 'http://localhost:3100',
+  auth: { type: 'basic', username: 'u', password: 'p' },
+});
+
+const bearer = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { type: 'bearer', token: async () => 'tok' },
+});
+
+const custom = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { type: 'custom', headers: { 'X-Api-Key': 'k' } },
+});
+
+// 2. Legacy shape still compiles (deprecated at runtime).
+const legacy = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { username: 'u', password: 'p' },
+});
+
+// 3. RetryOptions + defaultOrgId.
+const retry: RetryOptions = { attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 };
+const withRetry = new QrynClient({
+  baseUrl: 'http://x',
+  retry,
+  defaultOrgId: 'tenant-a',
+});
+
+// 4. Loki reader.
+async function lokiSmoke() {
+  const reader = basic.loki.createReader({ orgId: 'tenant-a' });
+  const opts: ReadOpts = { timeoutMs: 30_000, retry };
+  const inst = await reader.query('{job="x"}', new Date(), opts);
+  inst.response.data.resultType;
+
+  const range = await reader.queryRange(
+    '{job="x"}',
+    new Date(Date.now() - 3600_000),
+    new Date(),
+    '15s',
+    100,
+    'backward',
+    opts
+  );
+  range.response.data.result;
+
+  const labels = await reader.labels(undefined, undefined, opts);
+  labels.response.data;
+
+  await reader.labelValues('job', undefined, undefined, undefined, opts);
+  await reader.series(['{a="1"}'], undefined, undefined, opts);
+}
+
+// 5. Tempo.
+async function tempoSmoke() {
+  const t = basic.tempo;
+  const search: SearchOpts = { q: '{ duration > 1s }', limit: 5 };
+  await t.search(search, { signal: new AbortController().signal });
+  await t.searchTags('span');
+  await t.searchTagValues('service.name');
+  await t.getTrace('abc');
+}
+
+// 6. Errors are catchable as classes.
+async function errorSmoke() {
+  try {
+    await basic.tempo.search({ q: 'x' });
+  } catch (e) {
+    if (e instanceof QrynAbortedError) e.reason;
+    if (e instanceof QrynTimeoutError) e.elapsedMs;
+    if (e instanceof QrynError) e.statusCode;
+  }
+}
+
+void [basic, bearer, custom, legacy, withRetry, lokiSmoke, tempoSmoke, errorSmoke];
+```
+
+- [ ] **Step 2: Symlink (or npm-link) the package locally**
+
+The smoke imports from `'qryn-client'`. For `tsc` to resolve it, add a path mapping in [tsconfig.json](../../../tsconfig.json) instead of installing the package:
+
+Edit [tsconfig.json](../../../tsconfig.json) — replace the file:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "qryn-client": ["./index.d.ts"]
+    }
+  },
+  "include": ["index.d.ts", "tests/types/**/*"]
+}
+```
+
+- [ ] **Step 3: Run the type smoke**
+
+Run: `npm run test:types`
+Expected: exits 0 (no type errors).
+
+If it fails, the failure is real and must be fixed in [index.d.ts](../../../index.d.ts) or the consuming smoke.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/types/consumer-smoke.ts tsconfig.json
+git commit -m "add consumer type-smoke that compiles under --strict"
+```
+
+---
+
+## Task 14: Runtime smoke examples
+
+**Files:**
+- Create: [example/loki-read.js](../../../example/loki-read.js)
+- Create: [example/tempo.js](../../../example/tempo.js)
+
+These are not run in CI — they exist for the maintainer to validate against a live qryn. Keep them minimal and consistent with the existing [example/read.js](../../../example/read.js).
+
+- [ ] **Step 1: Create `example/loki-read.js`**
+
+Create [example/loki-read.js](../../../example/loki-read.js):
+
+```js
+const { QrynClient } = require('../src');
+
+const baseUrl = process.env.QYRN_READ_URL;
+const orgId   = process.env.QYRN_ORG_ID;
+
+if (!baseUrl) {
+  console.error('Set QYRN_READ_URL (and optionally QYRN_ORG_ID) to run this smoke.');
+  process.exit(2);
+}
+
+(async () => {
+  const client = new QrynClient({ baseUrl, defaultOrgId: orgId });
+  const reader = client.loki.createReader();
+
+  console.log('-- labels --');
+  const labels = await reader.labels();
+  console.log(labels.response);
+
+  console.log('-- queryRange --');
+  const end = new Date();
+  const start = new Date(end.getTime() - 60 * 60 * 1000);
+  const range = await reader.queryRange('{job=~".+"}', start, end, '60s', 5, 'backward');
+  console.log(JSON.stringify(range.response, null, 2).slice(0, 500));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Create `example/tempo.js`**
+
+Create [example/tempo.js](../../../example/tempo.js):
+
+```js
+const { QrynClient } = require('../src');
+
+const baseUrl = process.env.QYRN_READ_URL;
+const orgId   = process.env.QYRN_ORG_ID;
+
+if (!baseUrl) {
+  console.error('Set QYRN_READ_URL (and optionally QYRN_ORG_ID) to run this smoke.');
+  process.exit(2);
+}
+
+(async () => {
+  const client = new QrynClient({ baseUrl, defaultOrgId: orgId });
+
+  console.log('-- searchTags --');
+  const tags = await client.tempo.searchTags();
+  console.log(tags.response);
+
+  console.log('-- search --');
+  const found = await client.tempo.search({ q: '{}', limit: 5 });
+  console.log(JSON.stringify(found.response, null, 2).slice(0, 500));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Smoke-load both files (no network)**
+
+Run: `node -c example/loki-read.js && node -c example/tempo.js`
+Expected: exits 0 (syntax check only).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add example/loki-read.js example/tempo.js
+git commit -m "add example smokes for loki reader and tempo"
+```
+
+---
+
+## Task 15: README + architecture docs
+
+**Files:**
+- Modify: [README.md](../../../README.md)
+- Modify: [docs/architecture.md](../../../docs/architecture.md)
+
+- [ ] **Step 1: Update README**
+
+Add a "Migration to 1.1.0" section near the top of [README.md](../../../README.md), after the install instructions. Document:
+
+- New auth shape (basic/bearer/custom) with examples.
+- The legacy `{username, password}` shape still works but emits `DeprecationWarning` with code `QRYN_AUTH_LEGACY`.
+- New constructor options: `retry`, `defaultOrgId`.
+- Default `timeout` is now 60 s (was 5 s). Set `timeout: 5000` to restore the old default.
+- New per-call `opts` on every read method: `{ signal, timeoutMs, retry, orgId }`.
+- New errors: `QrynAbortedError`, `QrynTimeoutError`.
+- New `client.loki.createReader()` reader with full LogQL surface.
+- New tempo methods: `searchTags`, `searchTagValues`, `getTrace`.
+
+For each new surface, include a 5-10 line code example. Do not duplicate text already in `docs/architecture.md`; link to it.
+
+- [ ] **Step 2: Update architecture.md**
+
+Edit [docs/architecture.md](../../../docs/architecture.md). Update the HTTP and auth sections to reflect:
+
+- `Http.request` is now a per-call options pipeline (not constructor-time-only).
+- Retry + abort/timeout flow.
+- The auth resolver and the legacy shim.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/architecture.md
+git commit -m "document v1.1.0 surface (auth shapes, retry, abort, loki reader, tempo additions)"
+```
+
+---
+
+## Task 16: Bump version + final verification
+
+**Files:**
+- Modify: [package.json](../../../package.json)
+
+This is the last commit before merging. Run the full validation matrix.
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `npm test`
+Expected: all green.
+
+- [ ] **Step 2: Type emit + consumer smoke**
+
+Run: `npm run build:types && npm run test:types`
+Expected: both exit 0.
+
+- [ ] **Step 3: Public-surface require smoke**
+
+Run: `node -e "const m = require('./src'); console.log(Object.keys(m).sort())"`
+Expected: includes `Collector`, `Metric`, `QrynAbortedError`, `QrynClient`, `QrynError`, `QrynTimeoutError`, `Stream`.
+
+- [ ] **Step 4: Bump version**
+
+Edit [package.json](../../../package.json) — change `"version": "1.0.10"` to `"version": "1.1.0"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json
+git commit -m "bump version 1.0.10 -> 1.1.0"
+```
+
+- [ ] **Step 6: Inspect the commit graph**
+
+Run: `git log --oneline main..HEAD`
+Expected: a clean, lowercase, imperative-style commit list ending with the version bump.
+
+---
+
+## Out-of-scope reminder
+
+Do **not** in this branch:
+- Add any docker-compose / integration test infrastructure (P2).
+- Add the `QrynBadRequestError` / `QrynServerError` / `QrynNetworkError` hierarchy (P2 — only the two new error classes from this plan exist now).
+- Migrate any source file to TypeScript (recorded "Will not do").
+- Edit [src/services/remote.proto](../../../src/services/remote.proto) (vendored upstream).
+- Edit [.github/workflows/npm_release.yml](../../../.github/workflows/npm_release.yml).
+- Refactor the `Loki.push` / `Prometheus.push` validators (separate todo item, not this plan).
+
+If a step blocks on something not covered here, stop and surface it. Don't improvise.

--- a/docs/superpowers/specs/2026-05-02-coding-agent-readiness-design.md
+++ b/docs/superpowers/specs/2026-05-02-coding-agent-readiness-design.md
@@ -1,0 +1,100 @@
+# Coding-Agent Readiness — Design
+
+**Date:** 2026-05-02
+**Status:** Approved (verbal, auto mode)
+**Repo:** qryn-client (Node.js client library for qryn observability backend)
+
+## Goal
+
+Prepare this repository so that coding agents (Claude Code, Codex, Cursor, Copilot, Aider, etc.) can safely maintain and extend it without re-deriving conventions on every task. Produce an audit, fix the gaps, and put a single source of truth in front of any agent that opens the project.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Use `AGENTS.md` as the cross-tool standard; `CLAUDE.md` is a thin pointer to it. | Avoids duplicating instructions across vendor-specific files. |
+| 2 | Audit + fix the README + JSDoc completeness pass (Approach D from brainstorm). | Library is too small (~600 LOC) for a full `docs/` tree; JSDoc + README + AGENTS is right-sized. |
+| 3 | Fix all real bugs found during the audit, with backward compatibility preserved. | Bug fixes are in scope. Behavior-changing fixes are noted in the relevant section of `docs/AUDIT.md` so consumers can spot them in the changelog/PR. |
+| 4 | AGENTS.md depth = "Operational" (~200 lines): includes architecture, lifecycle invariants, known pitfalls, agent boundaries, and a recipe for adding a new client. | Captures the non-obvious context an agent cannot infer from reading code. |
+| 5 | No test suite added in this PR. Out of scope. | The audit will note absence of tests as a gap; adding them is a separate effort. |
+
+## Deliverables
+
+### Created
+- `AGENTS.md` — primary agent guidance (single source of truth).
+- `CLAUDE.md` — pointer to `AGENTS.md`, plus any Claude Code-specific notes.
+- `docs/AUDIT.md` — snapshot audit grouped by area (docs, code, infra, agent-readiness).
+- `docs/architecture.md` — one-page mental model of the data flow and lifecycles.
+- `docs/todo.md` — short post-fix backlog (anything left unaddressed in this PR).
+- `.aiexclude` — paths agents should not load into context (mirrors `.gitignore` plus secrets-shaped paths).
+
+### Updated
+- `README.md` — adds Tempo section, full Collector options table, documents `createCollector` and `headers` config, reconciles divergent examples.
+- `package.json` — fix placeholder GitHub URL (`username/qryn-client.git` → `metrico/qryn-client.git`).
+- `src/clients/loki.js` — fix header swap (`fpLimit` → `X-FP-Limit`, `ttlDays` → `X-Ttl-Days`); add JSDoc.
+- `src/clients/prometheus.js` — same header swap fix.
+- `src/clients/tempo.js` — throw `QrynError` instead of `console.error`-and-swallow; add full JSDoc; honor `orgId` in headers.
+- `src/services/http.js` — parse response body based on **response** content-type, not request content-type; handle 204/empty bodies.
+- `src/types/qrynResponse.js` — fix `getData()` typo (`this.data` → `this.response`); fix `toString()`'s undefined `this.type`/`this.data`.
+
+## Architecture (one-page)
+
+```
+                         ┌──────────────┐
+                         │ QrynClient   │
+                         └──────┬───────┘
+                  ┌─────────────┼─────────────┐
+                  ▼             ▼             ▼
+            ┌─────────┐  ┌────────────┐  ┌─────────┐
+            │  Loki   │  │ Prometheus │  │  Tempo  │
+            │ (logs)  │  │  (metrics) │  │ (traces)│
+            └────┬────┘  └─────┬──────┘  └────┬────┘
+                 │             │              │
+                 └─────────────┼──────────────┘
+                               ▼
+                         ┌──────────┐
+                         │   Http   │ ← shared transport
+                         └──────────┘
+
+  Stream  ──addEntry──▶  collect ──▶ Loki.push  ──confirm/undo──┐
+  Metric  ──addSample─▶  collect ──▶ Prom.push  ──confirm/undo──┤
+                                                                │
+  Collector wraps QrynClient ──▶ LRU-caches Stream/Metric by key
+                              ──▶ flushes on size OR timeout
+                              ──▶ retries with exponential backoff
+                              ──▶ emits 'info' / 'error' events
+```
+
+### Lifecycle invariants (CRITICAL)
+
+`Stream` and `Metric` carry an in-flight buffer for the optimistic push pattern:
+
+1. `addEntry` / `addSample` → buffers in `entries` / `samples`.
+2. `collect()` → snapshots and **clears** the buffer; result goes on the wire.
+3. `confirm()` (after server 2xx) → discards the snapshot.
+4. `undo()` (after error) → prepends the snapshot back so the next push retries it.
+
+**An agent must not break this contract.** If a new client subclass consumes a `Stream`/`Metric`, it MUST call `confirm()` on success and `undo()` on failure. Failing to call either leaks data.
+
+## Known issues (now fixed in this PR)
+
+These were behavior changes; consumers depending on the broken behavior would have been broken anyway. Each is documented in `docs/AUDIT.md` with file:line + before/after.
+
+- `fpLimit` and `ttlDays` collector options were mapped to swapped HTTP headers in both Loki and Prometheus push paths.
+- `QrynResponse.getData()` returned `undefined` because it referenced `this.data` (no such field; the data field is `this.response`).
+- `Http.request()` only parsed the response body when the **request** content-type was `application/x-www-form-urlencoded`. Most successful responses arrived with `response: {}`.
+- `Tempo.search()` swallowed errors via `console.error` instead of throwing, breaking the failover-via-`.catch()` pattern documented in the README.
+
+## Out of scope
+
+- Test suite (no harness exists; adding one is a separate effort tracked in `docs/todo.md`).
+- TypeScript migration / `.d.ts` generation.
+- API surface changes (renames, new endpoints).
+- Restructuring `src/` layout.
+
+## Success criteria
+
+1. An agent given the prompt "add a new Tempo endpoint" can do so by reading only `AGENTS.md` + the existing Tempo client.
+2. The four bugs above are fixed; manual smoke via `example/index.js` against a live qryn instance still works.
+3. `README.md` documents every public method that exists in `src/`.
+4. `git log --oneline` after the PR shows one commit per logical change (docs commit, bugfix commits separated).

--- a/docs/superpowers/specs/2026-05-02-qryn-client-v1.1-design.md
+++ b/docs/superpowers/specs/2026-05-02-qryn-client-v1.1-design.md
@@ -1,0 +1,326 @@
+# qryn-client v1.1.0 — design
+
+**Date:** 2026-05-02
+**Owner:** Shlomi Gutman
+**Status:** Draft, awaiting user approval
+**Source spec:** [docs/refreance/qryn-client-extensions-requirements.md](../../refreance/qryn-client-extensions-requirements.md)
+
+## Goal
+
+Land the P0 + P1 deliverables from the qryn-client extensions requirements as a single non-breaking minor release (v1.1.0). The release unblocks the Voicenter qryn-MCP build (P0) and gives the MCP its trace surface (P1). P2 (test harness, full error hierarchy) is deferred to a later brainstorm.
+
+## Decisions locked during brainstorm
+
+| # | Decision | Choice | Reason |
+|---|---|---|---|
+| 1 | TypeScript approach | Ship `.d.ts` only via `tsc --declaration --allowJs --emitDeclarationOnly` | Honors AGENTS.md (plain JS, no TS) and the recorded "Will not do" in [docs/todo.md](../../todo.md). Satisfies the source spec's `.d.ts` clause and the MCP's `tsc --noEmit --strict` consumer check. |
+| 2 | Scope | P0 + P1 in this design | P1 is small because Tempo client already exists; P2 is genuinely separable (testing infra + error hierarchy). |
+| 3 | Auth migration | Soft — accept old `{username, password}` shape with `process.emitWarning` deprecation; remove in 2.0.0 | Vendored MCP copy is SHA-pinned (per source spec); other v1.x consumers get a clear migration path; minor version bump suffices. |
+| 4 | Reader response shape | `QrynResponse<T>` with typed payload via `.d.ts` generics | Non-breaking for v1.x consumers; the source spec's "not raw axios" complaint is satisfied because `QrynResponse` is *our* envelope; avoids two coexisting return patterns. |
+
+## Reality reconciliation
+
+The source spec's "Current state" paragraph is dated. Confirmed actual state:
+
+- Library is published as `qryn-client` v1.0.10 ([package.json](../../../package.json)).
+- HTTP layer uses native `fetch` + `AbortSignal.timeout` ([src/services/http.js](../../../src/services/http.js)). No axios. Implementation references in the source spec to `axios-retry` and "axios's `signal` parameter" must be adapted to fetch.
+- `TempoClient` exists ([src/clients/tempo.js](../../../src/clients/tempo.js)) with `search`, `searchTagValuesV2`, `getTraceSpansJson`. P1 work is alignment + new methods, not greenfield.
+- `Prometheus.Read` reader exists ([src/clients/prometheus.js](../../../src/clients/prometheus.js)).
+- Auth is HTTP Basic only via `{username, password}` ([src/services/http.js:32](../../../src/services/http.js)).
+- JSDoc is in place across the public surface; no `.d.ts` is emitted today.
+- No test suite; smoke validation is via `example/*.js`.
+
+The source spec's release table (0.2.0 → 1.0.0) is therefore void. We ship as **v1.1.0**.
+
+## Architecture
+
+`QrynClient` continues to compose sub-clients sharing a single `Http` instance. The change is in three layers:
+
+```
+QrynClient (defaultOrgId, retry, auth, timeout, headers)
+  │
+  └─► Http (per-call: signal, timeoutMs, retry, orgId, authResolver)
+        │
+        ├─ loki   ── push (existing) + createReader() ──► LokiReader (new)
+        ├─ prom   ── push (existing) + createReader() ──► PromReader (existing, opts plumbed)
+        └─ tempo  ── search/searchTagValuesV2/getTraceSpansJson (existing) +
+                    searchTags + searchTagValues (new) + getTrace (alias of getTraceSpansJson)
+```
+
+Per-call options always override per-instance defaults. Existing call sites (e.g. `loki.push(streams, { orgId })`) continue to work unchanged.
+
+## Components
+
+### 1. HTTP layer — per-call options + retry + signals
+
+[src/services/http.js](../../../src/services/http.js) gains a per-call options pipeline:
+
+```js
+http.request(path, {
+  method, headers, body,    // existing
+  signal,                    // NEW — caller AbortSignal
+  timeoutMs,                 // NEW — overrides instance timeout for THIS request
+  retry,                     // NEW — RetryOptions; overrides instance default
+  orgId,                     // NEW — sets X-Scope-OrgID, overrides defaultOrgId
+  authResolver               // NEW — optional override for the resolved auth headers
+})
+```
+
+**Signal handling.** Each attempt computes its effective signal as `AbortSignal.any([callerSignal, AbortSignal.timeout(effectiveTimeoutMs)])`. `AbortSignal.any` is available in Node 20+; for Node 18 we ship a small polyfill in `src/utils/abort.js` that registers a one-time abort listener on the caller signal and forwards to a controller wrapping the timeout signal.
+
+When `fetch` rejects with `AbortError`:
+- If the caller signal is aborted → throw `QrynAbortedError(reason)`.
+- Otherwise (timeout) → throw `QrynTimeoutError(elapsedMs)`.
+
+These two new error classes are added to [src/types](../../../src/types/) and exported from `index.js`. They extend `QrynError`. The full `QrynBadRequestError`/`QrynServerError`/`QrynNetworkError` hierarchy from the source spec stays in P2.
+
+**Retry policy.**
+
+```ts
+interface RetryOptions {
+  attempts: number;             // default 3 (1 try + 2 retries)
+  baseDelayMs: number;          // default 200
+  maxDelayMs: number;           // default 5_000
+  retryOn?: (status: number, attempt: number) => boolean;
+}
+```
+
+Default retry condition (when `retryOn` is not supplied):
+- Network errors: `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`.
+- HTTP statuses: `408`, `429`, `502`, `503`, `504`.
+- Honor `Retry-After` on `429` (seconds OR HTTP-date).
+- Never retry on caller abort (`QrynAbortedError`).
+- Never retry on `4xx` other than `408` and `429`.
+
+Backoff: `min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1))` with full jitter (`Math.random() * delay`). When `Retry-After` is present on a `429`, use that value instead of computed backoff.
+
+**Per-attempt timeout budget.** Each attempt receives the full `timeoutMs` — retries do not double-count against the caller's deadline. A separate caller-supplied signal will still abort the entire chain at any moment.
+
+**Hand-rolled, no new deps.** `axios-retry` is rejected; we implement a small `retryRequest(http, path, options)` helper inside `Http`.
+
+### 2. Auth — discriminated union with soft migration
+
+`QrynClientOptions` becomes:
+
+```ts
+interface QrynClientOptions {
+  baseUrl?: string;                       // default 'http://localhost:3100'
+  auth?: QrynAuth;                        // discriminated union below
+  headers?: Record<string,string>;        // merged before auth headers
+  timeout?: number;                       // default per-call timeoutMs (default 60_000)
+  retry?: RetryOptions;                   // instance default
+  defaultOrgId?: string;                  // default X-Scope-OrgID
+}
+
+type QrynAuth =
+  | { type: 'basic',  username: string, password: string }
+  | { type: 'bearer', token: string | (() => Promise<string>) }
+  | { type: 'custom', headers: Record<string,string> | (() => Promise<Record<string,string>>) };
+```
+
+`Http` gains an `async #resolveAuthHeaders()` method:
+- `'basic'` → returns `{ Authorization: 'Basic ' + base64(user:pass) }`.
+- `'bearer'` → resolves token (string or thunk) → `{ Authorization: 'Bearer ' + token }`. Thunk is awaited each request.
+- `'custom'` → returns the headers map, awaiting the thunk if necessary.
+
+**Default timeout** rises from 5000 ms (current) to 60_000 ms to match the source spec acceptance for #3 ReadOpts. Push paths continue to honor the same default; consumers who relied on a 5 s push timeout can override per-call.
+
+**Back-compat shim.** In the `QrynClient` constructor, before passing to `Http`:
+
+```js
+if (auth && !auth.type && auth.username !== undefined) {
+  process.emitWarning(
+    "qryn-client: auth: { username, password } is deprecated; use auth: { type: 'basic', username, password }. The legacy shape will be removed in 2.0.0.",
+    'DeprecationWarning',
+    'QRYN_AUTH_LEGACY'
+  );
+  auth = { type: 'basic', username: auth.username, password: auth.password };
+}
+```
+
+`emitWarning` is fired with a unique code so consumers can suppress it (`--no-warnings=DeprecationWarning` or filtering by code).
+
+`auth` is optional throughout — an unauthenticated client is valid for local dev.
+
+### 3. LokiReader — new client
+
+New file [src/clients/loki-read.js](../../../src/clients/loki-read.js) plus a factory on the existing Loki client:
+
+```js
+// in src/clients/loki.js
+createReader(options = {}) {
+  return new LokiReader(this.service, options);
+}
+```
+
+```js
+// src/clients/loki-read.js
+class LokiReader {
+  constructor(service, options) { this.service = service; this.options = options; }
+
+  async query(query, time, opts) { /* GET /loki/api/v1/query */ }
+  async queryRange(query, start, end, step, limit, direction, opts) {
+    /* GET /loki/api/v1/query_range */
+  }
+  async labels(start, end, opts)                     { /* GET /loki/api/v1/labels */ }
+  async labelValues(label, start, end, match, opts)  { /* GET /loki/api/v1/label/{label}/values */ }
+  async series(matchers, start, end, opts)           { /* GET /loki/api/v1/series */ }
+}
+```
+
+**Endpoints** are GET with query-string params, matching what Grafana's Loki datasource sends:
+
+| Method | Path | Notable params |
+|---|---|---|
+| `query` | `/loki/api/v1/query` | `query`, `time` (ns) |
+| `queryRange` | `/loki/api/v1/query_range` | `query`, `start` (ns), `end` (ns), `step`, `limit`, `direction` |
+| `labels` | `/loki/api/v1/labels` | `start` (ns), `end` (ns) |
+| `labelValues` | `/loki/api/v1/label/{label}/values` | `start`, `end`, `query` (matcher) |
+| `series` | `/loki/api/v1/series` | repeated `match[]`, `start`, `end` |
+
+**Time normalization.** New util [src/utils/time.js](../../../src/utils/time.js) exports `toNanos(input: Date | number | string): string`. Rules:
+- `Date` → `(date.getTime() * 1e6).toString()`.
+- Integer `number` heuristic: `< 1e12` → seconds; `< 1e15` → milliseconds; otherwise nanoseconds. Each is multiplied to nanoseconds and emitted as a string to preserve precision.
+- `string` is returned unchanged (assume caller knows the unit).
+
+This addresses the source spec acceptance "Time params accept Date and unix-seconds number; nanosecond precision preserved for log timestamps."
+
+**ReadOpts.** All five methods accept a final `opts?: ReadOpts` argument:
+
+```ts
+interface ReadOpts {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  retry?: RetryOptions;
+  orgId?: string;
+}
+```
+
+`opts.orgId` overrides the per-instance `options.orgId` from `createReader`, which itself overrides client-level `defaultOrgId`.
+
+**Returns.** Every method returns `Promise<QrynResponse<T>>` per Q4-C. The `T` is one of the spec's named types (`LokiInstantResponse`, `LokiRangeResponse`, `string[]`, `SeriesResponse`). Runtime returns the raw envelope; the typed payload is expressed only in `.d.ts`.
+
+**Streams not materialized beyond `limit`.** The Loki API itself caps at `limit`; the client passes the parameter through. Live streaming (`tail`) is explicitly out of scope.
+
+### 4. PromReader — opts plumbing
+
+The existing [Read](../../../src/clients/prometheus.js) class gains an optional trailing `opts: ReadOpts` on each method (signal/timeoutMs/retry/orgId), forwarded to `Http.request`. Method signatures otherwise unchanged. Backward compatible.
+
+### 5. Tempo alignment
+
+Additions to [src/clients/tempo.js](../../../src/clients/tempo.js):
+
+| Surface | Status | Detail |
+|---|---|---|
+| `search(query, opts)` | Existing — generalize | First argument retains the existing meaning (raw query string fragment or `URLSearchParams`) for back-compat. New callers pass a `SearchOpts` object (`{ q, start, end, limit, spss }`); the implementation discriminates on the input type. `q` is the TraceQL query; the helper builds the query string from the object's fields. |
+| `searchTags(scope?, opts?)` | NEW | `GET /api/search/tags?scope=` (scope = `'span'\|'resource'\|'intrinsic'`). |
+| `searchTagValues(tag, opts?)` | NEW | `GET /api/search/tag/{tag}/values`. v1 path. |
+| `searchTagValuesV2` | Existing | Keep as-is. |
+| `getTrace(traceId, opts?)` | NEW alias | Thin alias of `getTraceSpansJson` to match the source spec name. Old method retained. |
+
+All methods grow `opts.signal`, `opts.timeoutMs`, `opts.retry`, `opts.orgId`. `searchParams` continues to accept `string | URLSearchParams` for back-compat.
+
+Returned shape per Q4-C: `Promise<QrynResponse<T>>` where `T` is `TempoSearchResponse`, `string[]`, or `TraceResponse`.
+
+### 6. Type emission (`.d.ts`)
+
+Add to [package.json](../../../package.json):
+
+```json
+{
+  "types": "index.d.ts",
+  "files": ["src", "index.d.ts", "dist/types"],
+  "scripts": {
+    "build:types": "tsc --declaration --allowJs --emitDeclarationOnly --target ES2020 --module commonjs --moduleResolution node --outDir dist/types src/index.js",
+    "test:types": "tsc --noEmit --strict tests/types/consumer-smoke.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+Keep a hand-written **[index.d.ts](../../../index.d.ts)** at the repo root that:
+1. Re-exports everything from `dist/types/index.d.ts` (the JSDoc-derived part).
+2. Augments with the named types JSDoc cannot express precisely:
+   `QrynAuth`, `RetryOptions`, `ReadOpts`, `LokiInstantResponse`, `LokiRangeResponse`, `SeriesResponse`, `TempoSearchResponse`, `TraceResponse`, `QrynResponse<T>` (generic).
+
+The release workflow ([.github/workflows/npm_release.yml](../../../.github/workflows/npm_release.yml)) runs `npm run build:types` before `npm publish`. CI runs `npm run test:types` to verify the consumer-smoke compiles under `--strict`.
+
+`tsconfig.json` is committed at the repo root with the bare-minimum config needed for the two scripts above; not used at runtime.
+
+### 7. Validation approach
+
+No test suite exists yet (deferred to P2). For this branch:
+
+- **Type smoke (CI).** [tests/types/consumer-smoke.ts](../../../tests/types/consumer-smoke.ts) imports the public API and exercises every new surface (basic/bearer/custom auth, `loki.createReader().queryRange(...)`, `tempo.searchTags(...)`, `ReadOpts`). Runs in CI as `npm run test:types`.
+- **Runtime smoke (manual).** [example/loki-read.js](../../../example/loki-read.js) (new), and additions to [example/read.js](../../../example/read.js) and [example/tempo.js](../../../example/tempo.js) (new) — driven by env vars, not part of CI.
+- **Existing baseline.** `node -e "require('./src')"` continues to pass on every commit.
+
+## Public API delta (for consumers)
+
+```js
+// New on QrynClient constructor
+new QrynClient({
+  baseUrl, headers, timeout,
+  auth: { type: 'basic'|'bearer'|'custom', ... },   // NEW shape
+  retry: { attempts, baseDelayMs, maxDelayMs, retryOn },   // NEW
+  defaultOrgId: 'tenant-a'                          // NEW
+});
+
+// NEW
+client.loki.createReader({ orgId? }).queryRange(q, start, end, step, limit, dir, opts);
+client.loki.createReader({ orgId? }).labels(start, end, opts);
+client.loki.createReader({ orgId? }).labelValues(label, start, end, match, opts);
+client.loki.createReader({ orgId? }).series(matchers, start, end, opts);
+client.loki.createReader({ orgId? }).query(q, time, opts);
+
+// NEW on Tempo
+client.tempo.searchTags(scope?, opts?);
+client.tempo.searchTagValues(tag, opts?);
+client.tempo.getTrace(traceId, opts?);   // alias
+
+// NEW errors
+QrynAbortedError, QrynTimeoutError    // exported from index.js
+```
+
+`opts` everywhere = `{ signal?, timeoutMs?, retry?, orgId? }`.
+
+## Files touched
+
+| Path | Change |
+|---|---|
+| [src/index.js](../../../src/index.js) | Constructor: accept new options, run auth back-compat shim, pass through to `Http`, expose new errors. |
+| [src/services/http.js](../../../src/services/http.js) | Per-call options pipeline, retry, signal combination, abort/timeout error mapping. |
+| [src/clients/loki.js](../../../src/clients/loki.js) | Add `createReader()`. Existing `push` behavior unchanged. |
+| **[src/clients/loki-read.js](../../../src/clients/loki-read.js)** (new) | `LokiReader` class. |
+| [src/clients/prometheus.js](../../../src/clients/prometheus.js) | Plumb `opts` through `Read` methods; no signature break. |
+| [src/clients/tempo.js](../../../src/clients/tempo.js) | New methods `searchTags`, `searchTagValues`, `getTrace`; per-call opts on existing methods. |
+| **[src/utils/time.js](../../../src/utils/time.js)** (new) | `toNanos` helper. |
+| **[src/utils/abort.js](../../../src/utils/abort.js)** (new) | `AbortSignal.any` shim for Node 18. |
+| [src/types/index.js](../../../src/types/index.js) | Export `QrynAbortedError`, `QrynTimeoutError`. |
+| **[src/types/qrynAbortedError.js](../../../src/types/qrynAbortedError.js)** (new) | New error class. |
+| **[src/types/qrynTimeoutError.js](../../../src/types/qrynTimeoutError.js)** (new) | New error class. |
+| **[index.d.ts](../../../index.d.ts)** (new) | Hand-written augmentation + re-export of generated types. |
+| **[tsconfig.json](../../../tsconfig.json)** (new) | Minimal config for `tsc --declaration`. |
+| [package.json](../../../package.json) | `types`, `files`, scripts, devDep on `typescript`. Bump version to 1.1.0. |
+| **[tests/types/consumer-smoke.ts](../../../tests/types/consumer-smoke.ts)** (new) | Strict type-check the public surface. |
+| **[example/loki-read.js](../../../example/loki-read.js)** (new) | Manual smoke. |
+| [example/tempo.js](../../../example/tempo.js) (new or extend) | Manual smoke for new tempo surface. |
+| [README.md](../../../README.md) | Document new auth shape, `createReader` for Loki, Tempo additions, retry/abort. |
+| [docs/architecture.md](../../../docs/architecture.md) | Update HTTP/auth section. |
+
+## Out of scope
+
+- Full `QrynBadRequestError` / `QrynServerError` / `QrynNetworkError` error hierarchy (P2).
+- Test harness — unit + integration + docker-compose (P2).
+- LogQL `tail` (live streaming).
+- Pyroscope / OTLP gRPC / Prometheus protobuf remote_write surface changes.
+- TypeScript source migration (recorded "Will not do" in [docs/todo.md](../../todo.md)).
+
+## Risks and notes
+
+- **`AbortSignal.any` polyfill.** Must be exercised in CI against the Node 18 version. We ship a small implementation; bug there means timeouts and caller aborts become tangled. Type-smoke does not catch this — needs an example/ smoke at minimum.
+- **Default timeout change (5 s → 60 s).** The current default is too low for analytic queries; raising it matches the source spec but is a behavioral change for v1.x users who relied on the 5 s cap. Document in README "Migration to 1.1.0" section.
+- **Hand-written `index.d.ts` over generated.** Keeping a hand-written file means the source-of-truth is split (JSDoc + index.d.ts). Acceptable cost for typed `QrynResponse<T>` and the named response shapes JSDoc cannot express. If JSDoc gains generic support adequate to our needs later, fold the hand-written portion back.
+- **`process.emitWarning` for auth deprecation.** Emitted once per process via the `QRYN_AUTH_LEGACY` code. Test suites that capture `process.on('warning', ...)` may see new noise. Documented in README.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,33 @@
+# TODO — post-audit backlog
+
+Items left after the 2026-05-02 coding-agent readiness audit. Prioritized roughly by ROI.
+
+## High value
+
+- [ ] **Add a test suite.** No tests exist today. Suggested first cut: `node:test` (built-in, no deps), one suite per public class, mock `fetch` via `globalThis.fetch = ...`. Prom remote-write encoding is the most fragile area and should be the first target.
+- [ ] **Add a PR-validation workflow.** Mirror the structure of `npm_release.yml`. Should run `node -e "require('./src')"` at minimum, then `npm test` once tests exist. Block merges on failure.
+- [ ] **Lock the response shape.** Now that `Http.request()` actually returns response bodies (audit fix B3), publish a `QrynResponse.response` schema for each endpoint in `docs/architecture.md` so consumers stop relying on guesswork.
+
+## Medium value
+
+- [ ] **Refactor `Loki.push` / `Prometheus.push` validators.** Replace the side-effecting `.every()` with a two-pass `filter(s instanceof Stream).filter(s => s.entries.length)`. Functionally identical, much easier to read. See `docs/AUDIT.md` "Code observations".
+- [ ] **Drop `Read` class from `prometheus.js`.** It's a separate concern (read path vs. write path) and pollutes `clients/prometheus.js`. Move to `src/clients/prometheus-read.js`.
+- [ ] **Add `getData()` deprecation note.** Now that it works (audit fix B2), but the field name `response` is also exposed directly, having two ways to read the body is redundant. Pick one.
+- [ ] **Document the `headers` config option** in the README API Reference (the constructor accepts it but it's only mentioned in JSDoc).
+
+## Low value / polish
+
+- [ ] **Generate `.d.ts` from JSDoc** via `tsc --declaration --allowJs --emitDeclarationOnly`. Consumers using TypeScript currently get no IntelliSense.
+- [ ] **Add a CHANGELOG.md.** Releases live only on GitHub Releases today.
+- [ ] **Adopt Conventional Commits** (project-wide decision; affects PR title bots).
+- [ ] **`example/` could use a README** explaining the env-var matrix.
+
+## Unblocked by future qryn changes
+
+- [ ] **Streaming push response (Loki).** Loki supports streamed responses for large pushes; the client always reads the full body. Worth revisiting once we add a test suite.
+
+## Will not do (recorded so it doesn't keep coming up)
+
+- **TypeScript migration.** Out of scope for now. JSDoc is the documented contract.
+- **Renaming `qrynResponse.response` → `qrynResponse.data`.** Tempting, but breaking. Not worth the churn.
+- **Bundling / dual ESM+CJS.** The library is a thin wrapper; consumers who need ESM can use the `default`/`named` interop their bundler provides.

--- a/example/loki-read.js
+++ b/example/loki-read.js
@@ -1,0 +1,27 @@
+const { QrynClient } = require('../src');
+
+const baseUrl = process.env.QYRN_READ_URL;
+const orgId   = process.env.QYRN_ORG_ID;
+
+if (!baseUrl) {
+  console.error('Set QYRN_READ_URL (and optionally QYRN_ORG_ID) to run this smoke.');
+  process.exit(2);
+}
+
+(async () => {
+  const client = new QrynClient({ baseUrl, defaultOrgId: orgId });
+  const reader = client.loki.createReader();
+
+  console.log('-- labels --');
+  const labels = await reader.labels();
+  console.log(labels.response);
+
+  console.log('-- queryRange --');
+  const end = new Date();
+  const start = new Date(end.getTime() - 60 * 60 * 1000);
+  const range = await reader.queryRange('{job=~".+"}', start, end, '60s', 5, 'backward');
+  console.log(JSON.stringify(range.response, null, 2).slice(0, 500));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/example/tempo.js
+++ b/example/tempo.js
@@ -1,0 +1,24 @@
+const { QrynClient } = require('../src');
+
+const baseUrl = process.env.QYRN_READ_URL;
+const orgId   = process.env.QYRN_ORG_ID;
+
+if (!baseUrl) {
+  console.error('Set QYRN_READ_URL (and optionally QYRN_ORG_ID) to run this smoke.');
+  process.exit(2);
+}
+
+(async () => {
+  const client = new QrynClient({ baseUrl, defaultOrgId: orgId });
+
+  console.log('-- searchTags --');
+  const tags = await client.tempo.searchTags();
+  console.log(tags.response);
+
+  console.log('-- search --');
+  const found = await client.tempo.search({ q: '{}', limit: 5 });
+  console.log(JSON.stringify(found.response, null, 2).slice(0, 500));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,198 @@
+// Hand-written TypeScript surface for qryn-client.
+// Augments declarations generated from JSDoc with named response types and
+// generic QrynResponse<T>. The runtime contract is the JS source in src/.
+
+import type { Agent } from 'http';
+
+// -- core errors --
+
+export class QrynError extends Error {
+  statusCode: number | null;
+  cause?: unknown;
+  path?: string;
+  constructor(message: string, statusCode?: number | null, cause?: unknown, path?: string);
+}
+
+export class QrynAbortedError extends QrynError {
+  reason?: unknown;
+}
+
+export class QrynTimeoutError extends QrynError {
+  elapsedMs: number;
+}
+
+// -- response wrapper --
+
+export class QrynResponse<T = unknown> {
+  response: T;
+  status: number;
+  headers: Headers | Record<string, string>;
+  path: string;
+  isSuccess(): boolean;
+  getData(): T;
+}
+
+// -- auth --
+
+export interface BasicAuth { type: 'basic'; username: string; password: string; }
+export interface BearerAuth { type: 'bearer'; token: string | (() => Promise<string>); }
+export interface CustomAuth {
+  type: 'custom';
+  headers: Record<string, string> | (() => Promise<Record<string, string>>);
+}
+export type QrynAuth = BasicAuth | BearerAuth | CustomAuth;
+
+// -- retry / read opts --
+
+export interface RetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  retryOn?: (status: number, attempt: number) => boolean;
+}
+
+export interface ReadOpts {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  retry?: RetryOptions;
+  orgId?: string;
+}
+
+// -- client config --
+
+export interface QrynClientOptions {
+  baseUrl?: string;
+  auth?: QrynAuth | { username: string; password: string };  // legacy shape accepted (deprecated)
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry?: RetryOptions;
+  defaultOrgId?: string;
+  agent?: Agent;
+}
+
+// -- Loki --
+
+export interface Stream {
+  addEntry(timestamp: number | string | Date, line: string): void;
+}
+
+export interface LokiPushOptions extends ReadOpts {
+  async?: boolean | string;
+  fpLimit?: number;
+  ttlDays?: number;
+}
+
+export interface LokiInstantResponse {
+  status: 'success' | string;
+  data: { resultType: string; result: unknown[] };
+}
+export interface LokiRangeResponse extends LokiInstantResponse {}
+export interface SeriesResponse {
+  status: 'success' | string;
+  data: Array<Record<string, string>>;
+}
+
+export class LokiReader {
+  query(query: string, time?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<LokiInstantResponse>>;
+  queryRange(
+    query: string,
+    start: Date | number | string,
+    end: Date | number | string,
+    step?: string,
+    limit?: number,
+    direction?: 'forward' | 'backward',
+    opts?: ReadOpts
+  ): Promise<QrynResponse<LokiRangeResponse>>;
+  labels(start?: Date | number | string, end?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<{ status: string; data: string[] }>>;
+  labelValues(label: string, start?: Date | number | string, end?: Date | number | string, match?: string, opts?: ReadOpts): Promise<QrynResponse<{ status: string; data: string[] }>>;
+  series(matchers: string[] | string, start?: Date | number | string, end?: Date | number | string, opts?: ReadOpts): Promise<QrynResponse<SeriesResponse>>;
+}
+
+export class Loki {
+  push(streams: Stream[], options?: LokiPushOptions): Promise<QrynResponse<unknown>>;
+  createReader(options?: { orgId?: string }): LokiReader;
+}
+
+// -- Prometheus --
+
+export interface Metric {
+  addSample(value: number, timestamp?: number): void;
+}
+
+export interface PromPushOptions extends ReadOpts {
+  async?: boolean | string;
+  fpLimit?: number;
+  ttlDays?: number;
+}
+
+export class PromReader {
+  query(query: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  queryRange(query: string, start: number, end: number, step: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  labels(opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  labelValues(labelName: string, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  series(match: string | string[], start: number, end: number, opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+  rules(opts?: ReadOpts): Promise<QrynResponse<unknown>>;
+}
+
+export class Prometheus {
+  push(metrics: Metric[], options?: PromPushOptions): Promise<QrynResponse<unknown> | undefined>;
+  createReader(options?: { orgId?: string }): PromReader;
+}
+
+// -- Tempo --
+
+export interface SearchOpts {
+  q: string;
+  start?: Date | number;
+  end?: Date | number;
+  limit?: number;
+  spss?: number;
+}
+
+export interface TempoSearchResponse {
+  traces?: Array<{
+    traceID: string;
+    rootServiceName?: string;
+    rootTraceName?: string;
+    durationMs?: number;
+    startTimeUnixNano?: string;
+    spanCount?: number;
+  }>;
+}
+
+export interface TraceResponse { batches: unknown[]; }
+
+export class TempoClient {
+  search(searchParams?: string | URLSearchParams | SearchOpts, options?: ReadOpts): Promise<QrynResponse<TempoSearchResponse>>;
+  searchTags(scope?: 'span' | 'resource' | 'intrinsic', options?: ReadOpts): Promise<QrynResponse<{ tagNames?: string[] }>>;
+  searchTagValues(tagName: string, options?: ReadOpts): Promise<QrynResponse<{ tagValues?: string[] }>>;
+  searchTagValuesV2(tagName: string, searchParams?: string | URLSearchParams, options?: ReadOpts): Promise<QrynResponse<unknown>>;
+  getTrace(traceId: string, options?: ReadOpts): Promise<QrynResponse<TraceResponse>>;
+  getTraceSpansJson(traceId: string, options?: ReadOpts): Promise<QrynResponse<TraceResponse>>;
+}
+
+// -- Collector --
+
+export interface CollectorOptions {
+  maxBulkSize?: number;
+  maxTimeout?: number;
+}
+
+export class Collector {
+  pushStream(stream: Stream): void;
+  pushMetric(metric: Metric): void;
+  flush(): Promise<void>;
+}
+
+// -- Client --
+
+export class QrynClient {
+  constructor(config: QrynClientOptions);
+  loki: Loki;
+  prom: Prometheus;
+  tempo: TempoClient;
+
+  createCollector(config?: CollectorOptions): Collector;
+  createStream(labels: Record<string, string>): Stream;
+  createMetric(input: { name: string; labels?: Record<string, string> }): Metric;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,12 +23,12 @@ export class QrynTimeoutError extends QrynError {
 
 // -- response wrapper --
 
-export class QrynResponse<T = unknown> {
+export interface QrynResponse<T = unknown> {
   response: T;
   status: number;
   headers: Headers | Record<string, string>;
   path: string;
-  isSuccess(): boolean;
+  readonly isSuccess: boolean;
   getData(): T;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qryn-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A client library for interacting with qryn, a high-performance observability backend.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,19 +15,23 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/username/qryn-client.git"
+    "url": "https://github.com/metrico/qryn-client.git"
   },
   "keywords": [
     "qryn",
     "client",
     "observability",
     "monitoring",
-    "logging"
+    "logging",
+    "loki",
+    "prometheus",
+    "tempo",
+    "tracing"
   ],
   "bugs": {
-    "url": "https://github.com/username/qryn-client/issues"
+    "url": "https://github.com/metrico/qryn-client/issues"
   },
-  "homepage": "https://github.com/username/qryn-client#readme",
+  "homepage": "https://github.com/metrico/qryn-client#readme",
   "engines": {
     "node": ">=18.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A client library for interacting with qryn, a high-performance observability backend.",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/unit/*.test.js"
   },
   "author": "tzachiSh",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "^11.0.1",
-    "protobufjs": "^7.3.2",
+    "protobufjs": "^8.0.3",
     "snappy": "^7.2.2"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qryn-client",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "A client library for interacting with qryn, a high-performance observability backend.",
   "main": "src/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,16 @@
   "version": "1.0.10",
   "description": "A client library for interacting with qryn, a high-performance observability backend.",
   "main": "src/index.js",
+  "types": "index.d.ts",
+  "files": [
+    "src",
+    "index.d.ts",
+    "dist/types"
+  ],
   "scripts": {
-    "test": "node --test tests/unit/*.test.js"
+    "test": "node --test tests/unit/*.test.js",
+    "test:types": "tsc -p tsconfig.json",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "author": "tzachiSh",
   "license": "MIT",
@@ -34,5 +42,8 @@
   "homepage": "https://github.com/metrico/qryn-client#readme",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
   }
 }

--- a/src/clients/loki-read.js
+++ b/src/clients/loki-read.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const { QrynError } = require('../types');
+const { toNanos } = require('../utils/time');
+
+/**
+ * Loki read client — LogQL queries, labels, label values, series.
+ * @see https://grafana.com/docs/loki/latest/reference/loki-http-api/
+ */
+class LokiReader {
+  /**
+   * @param {import('../services/http')} service
+   * @param {{ orgId?: string }} [options]
+   */
+  constructor(service, options = {}) {
+    this.service = service;
+    this.options = options;
+  }
+
+  /**
+   * Instant LogQL query.
+   * @param {string} query
+   * @param {Date|number|string} [time]
+   * @param {Object} [opts]
+   */
+  async query(query, time, opts = {}) {
+    const params = new URLSearchParams();
+    params.set('query', query);
+    if (time !== undefined) params.set('time', toNanos(time));
+    return this.#get('/loki/api/v1/query', params, opts, 'query');
+  }
+
+  /**
+   * Range LogQL query.
+   */
+  async queryRange(query, start, end, step, limit, direction, opts = {}) {
+    const params = new URLSearchParams();
+    params.set('query', query);
+    params.set('start', toNanos(start));
+    params.set('end', toNanos(end));
+    if (step !== undefined) params.set('step', String(step));
+    if (limit !== undefined) params.set('limit', String(limit));
+    if (direction !== undefined) params.set('direction', String(direction));
+    return this.#get('/loki/api/v1/query_range', params, opts, 'queryRange');
+  }
+
+  /**
+   * List label names.
+   */
+  async labels(start, end, opts = {}) {
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    return this.#get('/loki/api/v1/labels', params, opts, 'labels');
+  }
+
+  /**
+   * Values for a single label.
+   */
+  async labelValues(label, start, end, match, opts = {}) {
+    if (!label) throw new QrynError('label parameter is required');
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    if (match !== undefined) params.set('query', String(match));
+    return this.#get(
+      `/loki/api/v1/label/${encodeURIComponent(label)}/values`,
+      params,
+      opts,
+      'labelValues'
+    );
+  }
+
+  /**
+   * Series matching one or more matchers.
+   */
+  async series(matchers, start, end, opts = {}) {
+    if (!matchers) throw new QrynError('matchers parameter is required');
+    const list = Array.isArray(matchers) ? matchers : [matchers];
+    const params = new URLSearchParams();
+    if (start !== undefined) params.set('start', toNanos(start));
+    if (end !== undefined) params.set('end', toNanos(end));
+    list.forEach(m => params.append('match[]', m));
+    return this.#get('/loki/api/v1/series', params, opts, 'series');
+  }
+
+  async #get(basePath, params, opts, verb) {
+    const qs = params.toString();
+    const path = qs ? `${basePath}?${qs}` : basePath;
+    return this.service.request(path, {
+      method: 'GET',
+      headers: this.#headers(opts),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options.orgId
+    }).catch(error => {
+      if (error instanceof QrynError) throw error;
+      throw new QrynError(`Loki ${verb} failed: ${error.message}`, error.statusCode);
+    });
+  }
+
+  #headers(_opts) {
+    return {
+      'Accept': 'application/json'
+    };
+  }
+}
+
+module.exports = LokiReader;

--- a/src/clients/loki.js
+++ b/src/clients/loki.js
@@ -38,7 +38,10 @@ class Loki {
       const response = await this.service.request('/loki/api/v1/push', {
         method: 'POST',
         headers,
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
+        signal: options.signal,
+        timeoutMs: options.timeoutMs,
+        retry: options.retry
       });
 
       streams.forEach(s => s.confirm());

--- a/src/clients/loki.js
+++ b/src/clients/loki.js
@@ -41,7 +41,8 @@ class Loki {
         body: JSON.stringify(payload),
         signal: options.signal,
         timeoutMs: options.timeoutMs,
-        retry: options.retry
+        retry: options.retry,
+        orgId: options.orgId
       });
 
       streams.forEach(s => s.confirm());

--- a/src/clients/loki.js
+++ b/src/clients/loki.js
@@ -56,6 +56,16 @@ class Loki {
   }
 
   /**
+   * Create a LokiReader bound to this client's service.
+   * @param {{ orgId?: string }} [options]
+   * @returns {import('./loki-read')}
+   */
+  createReader(options = {}) {
+    const LokiReader = require('./loki-read');
+    return new LokiReader(this.service, options);
+  }
+
+  /**
    * Build per-request headers from push options.
    * @param {Object} [options={}] - Push options.
    * @param {string} [options.orgId]   - Multi-tenant routing → `X-Scope-OrgID`.

--- a/src/clients/loki.js
+++ b/src/clients/loki.js
@@ -52,12 +52,21 @@ class Loki {
     }
   }
 
+  /**
+   * Build per-request headers from push options.
+   * @param {Object} [options={}] - Push options.
+   * @param {string} [options.orgId]   - Multi-tenant routing → `X-Scope-OrgID`.
+   * @param {string|boolean} [options.async] - Non-blocking insert → `X-Async-Insert`.
+   * @param {number} [options.fpLimit] - Fingerprint cap → `X-FP-Limit`.
+   * @param {number} [options.ttlDays] - Retention override → `X-Ttl-Days`.
+   * @returns {Object} Header map.
+   */
   headers(options = {}) {
     const headers = {};
     if (options.orgId) headers['X-Scope-OrgID'] = options.orgId;
     if (options.async) headers['X-Async-Insert'] = options.async;
-    if (options.fpLimit) headers['X-Ttl-Days'] = options.fpLimit;
-    if (options.ttlDays) headers['X-FP-LIMIT'] = options.ttlDays;
+    if (options.fpLimit) headers['X-FP-Limit'] = options.fpLimit;
+    if (options.ttlDays) headers['X-Ttl-Days'] = options.ttlDays;
     return headers;
   }
 }

--- a/src/clients/prometheus.js
+++ b/src/clients/prometheus.js
@@ -202,6 +202,15 @@ class Prometheus {
     return new Read(this.service, options);
   }
 
+  /**
+   * Build remote-write headers from push options.
+   * @param {Object} [options={}] - Push options.
+   * @param {string} [options.orgId]   - Multi-tenant routing → `X-Scope-OrgID`.
+   * @param {string|boolean} [options.async] - Non-blocking insert → `X-Async-Insert`.
+   * @param {number} [options.fpLimit] - Fingerprint cap → `X-FP-Limit`.
+   * @param {number} [options.ttlDays] - Retention override → `X-Ttl-Days`.
+   * @returns {Object} Header map.
+   */
   headers(options = {}) {
     let headers = {
       'Content-Type': 'application/x-protobuf',
@@ -210,8 +219,8 @@ class Prometheus {
     };
     if (options.orgId) headers['X-Scope-OrgID'] = options.orgId;
     if (options.async) headers['X-Async-Insert'] = options.async;
-    if (options.fpLimit) headers['X-Ttl-Days'] = options.fpLimit;
-    if (options.ttlDays) headers['X-FP-LIMIT'] = options.ttlDays;
+    if (options.fpLimit) headers['X-FP-Limit'] = options.fpLimit;
+    if (options.ttlDays) headers['X-Ttl-Days'] = options.ttlDays;
     return headers;
   }
 }

--- a/src/clients/prometheus.js
+++ b/src/clients/prometheus.js
@@ -14,14 +14,19 @@ class Read {
   /**
    * Execute a PromQL query and retrieve the result.
    * @param {string} query - The PromQL query string.
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the query endpoint.
    * @throws {QrynError} If the query request fails.
    */
-  async query(query) {
+  async query(query, opts = {}) {
     return this.service.request('/api/v1/query', {
       method: 'POST',
       headers: this.headers(),
-      body: { query }
+      body: { query },
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -36,15 +41,20 @@ class Read {
    * @param {number} start - The start timestamp in seconds.
    * @param {number} end - The end timestamp in seconds.
    * @param {string} step - The query resolution step width in duration format (e.g., '15s').
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the query range endpoint.
    * @throws {QrynError} If the query range request fails.
    */
-  async queryRange(query, start, end, step) {
+  async queryRange(query, start, end, step, opts = {}) {
 
     return this.service.request('/api/v1/query_range', {
       method: 'POST',
       headers: this.headers(),
-      body: new URLSearchParams({query, start, end, step})
+      body: new URLSearchParams({query, start, end, step}),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -55,13 +65,18 @@ class Read {
 
   /**
    * Retrieve the list of label names.
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the labels endpoint.
    * @throws {QrynError} If the labels request fails.
    */
-  async labels() {
+  async labels(opts = {}) {
     return this.service.request('/api/v1/labels', {
       method: 'GET',
-      headers: this.headers()
+      headers: this.headers(),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -73,13 +88,18 @@ class Read {
   /**
    * Retrieve the list of label values for a specific label name.
    * @param {string} labelName - The name of the label.
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the label values endpoint.
    * @throws {QrynError} If the label values request fails.
    */
-  async labelValues(labelName) {
+  async labelValues(labelName, opts = {}) {
     return this.service.request(`/api/v1/label/${labelName}/values`, {
       method: 'GET',
-      headers: this.headers()
+      headers: this.headers(),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -93,10 +113,11 @@ class Read {
    * @param {Array} match - The label set to match.
    * @param {number} start - The start timestamp in seconds.
    * @param {number} end - The end timestamp in seconds.
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the series endpoint.
    * @throws {QrynError} If the series request fails.
    */
-  async series(match, start, end) {
+  async series(match, start, end, opts = {}) {
     let params = new URLSearchParams({start, end })
     if(!match) throw new QrynError('match parameter is required');
     if(typeof match  === 'string') match = [match];
@@ -105,7 +126,11 @@ class Read {
     return this.service.request('/api/v1/series', {
       method: 'POST',
       headers: this.headers(),
-      body: params
+      body: params,
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -116,13 +141,18 @@ class Read {
 
   /**
    * Retrieve the currently loaded alerting and recording rules.
+   * @param {ReadOpts} [opts] - Per-call options (signal, timeoutMs, retry, orgId).
    * @returns {Promise<QrynResponse>} A promise that resolves to the response from the rules endpoint.
    * @throws {QrynError} If the rules request fails.
    */
-  async rules() {
+  async rules(opts = {}) {
     return this.service.request('/api/v1/rules', {
       method: 'GET',
-      headers: this.headers()
+      headers: this.headers(),
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs,
+      retry: opts.retry,
+      orgId: opts.orgId ?? this.options?.orgId
     }).catch(error => {
       if (error instanceof QrynError) {
         throw error;
@@ -135,7 +165,7 @@ class Read {
     let headers = {
       'Content-Type': 'application/x-www-form-urlencoded'
     };
-    if (this.options.orgId) headers['X-Scope-OrgID'] = this.options.orgId;
+    if (this.options?.orgId) headers['X-Scope-OrgID'] = this.options.orgId;
     return headers;
   }
 }
@@ -180,7 +210,10 @@ class Prometheus {
     return this.service.request('/api/v1/prom/remote/write', {
       method: 'POST',
       headers: this.headers(options),
-      body: compressedBuffer
+      body: compressedBuffer,
+      signal: options && options.signal,
+      timeoutMs: options && options.timeoutMs,
+      retry: options && options.retry
     }).then(res => {
       metrics.forEach(metric => metric.confirm());
       return res;

--- a/src/clients/prometheus.js
+++ b/src/clients/prometheus.js
@@ -213,7 +213,8 @@ class Prometheus {
       body: compressedBuffer,
       signal: options && options.signal,
       timeoutMs: options && options.timeoutMs,
-      retry: options && options.retry
+      retry: options && options.retry,
+      orgId: options && options.orgId
     }).then(res => {
       metrics.forEach(metric => metric.confirm());
       return res;

--- a/src/clients/tempo.js
+++ b/src/clients/tempo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { QrynError } = require('../types');
 
 /**
@@ -5,84 +7,118 @@ const { QrynError } = require('../types');
  * @see https://grafana.com/docs/tempo/latest/api_docs/
  */
 class TempoClient {
-    /**
-     * @param {import('../services/http')} service - The shared Http service.
-     */
-    constructor(service) {
-        this.service = service;
-    }
+  /**
+   * @param {import('../services/http')} service
+   */
+  constructor(service) {
+    this.service = service;
+  }
 
-    /**
-     * Search for traces.
-     * @param {string|URLSearchParams} [searchParams] - Query string (without leading `?`) or `URLSearchParams`.
-     * @param {Object} [options]
-     * @param {string} [options.orgId] - Multi-tenant org id → `X-Scope-OrgID`.
-     * @returns {Promise<import('../types/qrynResponse')>} A QrynResponse on 2xx.
-     * @throws {QrynError} On any non-2xx or network/timeout error.
-     */
-    async search(searchParams, options = {}) {
-        const qs = searchParams ? String(searchParams) : '';
-        return this.service.request(`/api/search?${qs}`, {
-            method: 'GET',
-            headers: this.headers(options)
-        }).catch(error => {
-            if (error instanceof QrynError) throw error;
-            throw new QrynError(`Tempo search failed: ${error.message}`, error.statusCode);
-        });
-    }
+  /**
+   * TraceQL search.
+   * The first argument has three accepted shapes:
+   *   - string: treated as a raw query string fragment (back-compat).
+   *   - URLSearchParams: serialized directly (back-compat).
+   *   - SearchOpts object: { q, start, end, limit, spss } — built into the query string.
+   *
+   * @param {string|URLSearchParams|{q:string,start?:Date|number,end?:Date|number,limit?:number,spss?:number}} [searchParams]
+   * @param {Object} [options]
+   * @param {string} [options.orgId]
+   * @param {AbortSignal} [options.signal]
+   * @param {number} [options.timeoutMs]
+   * @param {Object} [options.retry]
+   */
+  async search(searchParams, options = {}) {
+    const qs = this.#searchParamsToString(searchParams);
+    return this.#get(`/api/search${qs ? `?${qs}` : ''}`, options, 'search');
+  }
 
-    /**
-     * Retrieve the values for a given trace tag (Tempo v2 search API).
-     * @param {string} tagName - Tag name (e.g. `service.name`).
-     * @param {string|URLSearchParams} [searchParams] - Optional query string.
-     * @param {Object} [options]
-     * @param {string} [options.orgId]
-     * @returns {Promise<import('../types/qrynResponse')>}
-     * @throws {QrynError}
-     */
-    async searchTagValuesV2(tagName, searchParams, options = {}) {
-        const qs = searchParams ? String(searchParams) : '';
-        return this.service.request(`/api/v2/search/tag/${tagName}/values?${qs}`, {
-            method: 'GET',
-            headers: this.headers(options)
-        }).catch(error => {
-            if (error instanceof QrynError) throw error;
-            throw new QrynError(`Tempo searchTagValuesV2 failed: ${error.message}`, error.statusCode);
-        });
-    }
+  /**
+   * GET /api/search/tags
+   * @param {'span'|'resource'|'intrinsic'} [scope]
+   * @param {Object} [options] - opts.signal/timeoutMs/retry/orgId
+   */
+  async searchTags(scope, options = {}) {
+    const path = scope ? `/api/search/tags?scope=${encodeURIComponent(scope)}` : '/api/search/tags';
+    return this.#get(path, options, 'searchTags');
+  }
 
-    /**
-     * Fetch the full set of spans for a single trace ID.
-     * @param {string} traceID - Hex-encoded trace id.
-     * @param {Object} [options]
-     * @param {string} [options.orgId]
-     * @returns {Promise<import('../types/qrynResponse')>}
-     * @throws {QrynError}
-     */
-    async getTraceSpansJson(traceID, options = {}) {
-        return this.service.request(`/api/traces/${traceID}/json`, {
-            method: 'GET',
-            headers: this.headers(options)
-        }).catch(error => {
-            if (error instanceof QrynError) throw error;
-            throw new QrynError(`Tempo getTraceSpansJson failed: ${error.message}`, error.statusCode);
-        });
-    }
+  /**
+   * GET /api/search/tag/{tag}/values  (v1)
+   */
+  async searchTagValues(tagName, options = {}) {
+    if (!tagName) throw new QrynError('tagName is required');
+    return this.#get(
+      `/api/search/tag/${encodeURIComponent(tagName)}/values`,
+      options,
+      'searchTagValues'
+    );
+  }
 
-    /**
-     * Build per-request headers.
-     * @param {Object} [options={}]
-     * @param {string} [options.orgId]
-     * @returns {Object} Header map.
-     */
-    headers(options = {}) {
-        const headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-        };
-        if (options.orgId) headers['X-Scope-OrgID'] = options.orgId;
-        return headers;
+  /**
+   * GET /api/v2/search/tag/{tagName}/values
+   */
+  async searchTagValuesV2(tagName, searchParams, options = {}) {
+    const qs = this.#searchParamsToString(searchParams);
+    const path = `/api/v2/search/tag/${encodeURIComponent(tagName)}/values${qs ? `?${qs}` : ''}`;
+    return this.#get(path, options, 'searchTagValuesV2');
+  }
+
+  /**
+   * GET /api/traces/{traceId}/json
+   * Existing method — kept for back-compat.
+   */
+  async getTraceSpansJson(traceID, options = {}) {
+    return this.#get(`/api/traces/${encodeURIComponent(traceID)}/json`, options, 'getTraceSpansJson');
+  }
+
+  /**
+   * Spec-aligned alias of getTraceSpansJson.
+   */
+  async getTrace(traceID, options = {}) {
+    return this.getTraceSpansJson(traceID, options);
+  }
+
+  // -- helpers --
+
+  #searchParamsToString(input) {
+    if (input == null) return '';
+    if (typeof input === 'string') return input;
+    if (input instanceof URLSearchParams) return input.toString();
+    if (typeof input === 'object') {
+      const params = new URLSearchParams();
+      if (input.q !== undefined)     params.set('q', input.q);
+      if (input.start !== undefined) params.set('start', String(input.start instanceof Date ? input.start.getTime() : input.start));
+      if (input.end !== undefined)   params.set('end',   String(input.end   instanceof Date ? input.end.getTime()   : input.end));
+      if (input.limit !== undefined) params.set('limit', String(input.limit));
+      if (input.spss !== undefined)  params.set('spss',  String(input.spss));
+      return params.toString();
     }
+    return String(input);
+  }
+
+  #headers(options) {
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    };
+    if (options.orgId) headers['X-Scope-OrgID'] = options.orgId;
+    return headers;
+  }
+
+  async #get(path, options, verb) {
+    return this.service.request(path, {
+      method: 'GET',
+      headers: this.#headers(options),
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+      retry: options.retry,
+      orgId: options.orgId
+    }).catch(error => {
+      if (error instanceof QrynError) throw error;
+      throw new QrynError(`Tempo ${verb} failed: ${error.message}`, error.statusCode);
+    });
+  }
 }
 
 module.exports = TempoClient;

--- a/src/clients/tempo.js
+++ b/src/clients/tempo.js
@@ -1,36 +1,82 @@
-const {QrynError} = require("../types");
+const { QrynError } = require('../types');
 
+/**
+ * Tempo client — read-side access to traces stored in qryn.
+ * @see https://grafana.com/docs/tempo/latest/api_docs/
+ */
 class TempoClient {
     /**
-     * Create a new Tempo instance.
-     * @param {Http} service - The HTTP service to use for requests.
+     * @param {import('../services/http')} service - The shared Http service.
      */
     constructor(service) {
         this.service = service;
     }
 
-    async search(searchParams) {
-        return this.service.request(`/api/search?${searchParams ? searchParams : ''}`, {
-            method: 'GET'
+    /**
+     * Search for traces.
+     * @param {string|URLSearchParams} [searchParams] - Query string (without leading `?`) or `URLSearchParams`.
+     * @param {Object} [options]
+     * @param {string} [options.orgId] - Multi-tenant org id → `X-Scope-OrgID`.
+     * @returns {Promise<import('../types/qrynResponse')>} A QrynResponse on 2xx.
+     * @throws {QrynError} On any non-2xx or network/timeout error.
+     */
+    async search(searchParams, options = {}) {
+        const qs = searchParams ? String(searchParams) : '';
+        return this.service.request(`/api/search?${qs}`, {
+            method: 'GET',
+            headers: this.headers(options)
         }).catch(error => {
-            console.error('ERROR:', error)
+            if (error instanceof QrynError) throw error;
+            throw new QrynError(`Tempo search failed: ${error.message}`, error.statusCode);
         });
     }
 
-    async searchTagValuesV2(tagName, searchParams) {
-        return this.service.request(`/api/v2/search/tag/${tagName}/values?${searchParams ? searchParams : ''}`, {
-            method: 'GET'
-        })
+    /**
+     * Retrieve the values for a given trace tag (Tempo v2 search API).
+     * @param {string} tagName - Tag name (e.g. `service.name`).
+     * @param {string|URLSearchParams} [searchParams] - Optional query string.
+     * @param {Object} [options]
+     * @param {string} [options.orgId]
+     * @returns {Promise<import('../types/qrynResponse')>}
+     * @throws {QrynError}
+     */
+    async searchTagValuesV2(tagName, searchParams, options = {}) {
+        const qs = searchParams ? String(searchParams) : '';
+        return this.service.request(`/api/v2/search/tag/${tagName}/values?${qs}`, {
+            method: 'GET',
+            headers: this.headers(options)
+        }).catch(error => {
+            if (error instanceof QrynError) throw error;
+            throw new QrynError(`Tempo searchTagValuesV2 failed: ${error.message}`, error.statusCode);
+        });
     }
 
-    async getTraceSpansJson(traceID) {
+    /**
+     * Fetch the full set of spans for a single trace ID.
+     * @param {string} traceID - Hex-encoded trace id.
+     * @param {Object} [options]
+     * @param {string} [options.orgId]
+     * @returns {Promise<import('../types/qrynResponse')>}
+     * @throws {QrynError}
+     */
+    async getTraceSpansJson(traceID, options = {}) {
         return this.service.request(`/api/traces/${traceID}/json`, {
-            method: 'GET'
-        })
+            method: 'GET',
+            headers: this.headers(options)
+        }).catch(error => {
+            if (error instanceof QrynError) throw error;
+            throw new QrynError(`Tempo getTraceSpansJson failed: ${error.message}`, error.statusCode);
+        });
     }
 
-    headers(options) {
-        let headers = {
+    /**
+     * Build per-request headers.
+     * @param {Object} [options={}]
+     * @param {string} [options.orgId]
+     * @returns {Object} Header map.
+     */
+    headers(options = {}) {
+        const headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json'
         };
@@ -39,4 +85,4 @@ class TempoClient {
     }
 }
 
-module.exports = TempoClient
+module.exports = TempoClient;

--- a/src/index.js
+++ b/src/index.js
@@ -1,91 +1,74 @@
-const {Stream, Metric} = require('./models')
-const PrometheusClient = require('./clients/prometheus')
+const {Stream, Metric} = require('./models');
+const PrometheusClient = require('./clients/prometheus');
 const Collector = require('./utils/collector');
-const LokiClient = require('./clients/loki')
-const TempoClient = require('./clients/tempo')
-const Http = require('./services/http')
+const LokiClient = require('./clients/loki');
+const TempoClient = require('./clients/tempo');
+const Http = require('./services/http');
+const {
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError
+} = require('./types');
+const { normalizeAuth } = require('./services/auth');
 
-
-
-class Auth{
-  constructor({username, password}){
-    this.username = username;
-    this.password = password;
-  }
-}
-
+let __legacyAuthWarned = false;
 
 /**
  * Main client for qryn operations.
  */
 class QrynClient {
   /**
-   * Create a QrynClient.
-   * @param {Object} config - The configuration object.
-   * @param {string} [config.baseUrl='http://localhost:3100'] - The base URL for the qryn server.
-   * @param {Auth} [config.auth] - The base Auth for the qryn server.
-   * @param {number} [config.timeout=5000] - The timeout for requests in milliseconds.
-   * @param {Object} [config.headers={}] - Additional headers to send with requests.
+   * @param {Object} config
+   * @param {string} [config.baseUrl='http://localhost:3100']
+   * @param {import('./services/auth').QrynAuth | {username:string,password:string}} [config.auth]
+   * @param {number} [config.timeout=60000]
+   * @param {Object} [config.headers={}]
+   * @param {import('./utils/retry').RetryOptions} [config.retry]
+   * @param {string} [config.defaultOrgId]
    */
   constructor(config) {
     if (typeof config !== 'object' || config === null) {
       throw new QrynError('Config must be a non-null object');
     }
-    const auth = config.auth
+
+    const { auth, legacy } = normalizeAuth(config.auth);
+    if (legacy && !__legacyAuthWarned) {
+      __legacyAuthWarned = true;
+      process.emitWarning(
+        "qryn-client: auth: { username, password } is deprecated; use auth: { type: 'basic', username, password }. The legacy shape will be removed in 2.0.0.",
+        'DeprecationWarning',
+        'QRYN_AUTH_LEGACY'
+      );
+    }
+
     const baseUrl = config.baseUrl || 'http://localhost:3100';
-    const timeout = config.timeout || 5000;
+    const timeout = config.timeout || 60000;
     const headers = {
       'Content-Type': 'application/json',
       ...config.headers
     };
-    const http = new Http(baseUrl, timeout, headers, auth);
+
+    const http = new Http(baseUrl, timeout, headers, auth, {
+      retry: config.retry,
+      defaultOrgId: config.defaultOrgId
+    });
+
     this.prom = new PrometheusClient(http);
     this.loki = new LokiClient(http);
     this.tempo = new TempoClient(http);
   }
 
-  /**
-   * Creates a new Collector instance.
-   *
-   * @param {Object} [config] - The configuration options for the Collector.
-   * @param {number} [config.maxBulkSize=1000] - The maximum number of items to store in the bulk before pushing.
-   * @param {number} [config.maxTimeout=5000] - The maximum time in milliseconds to wait before pushing the bulk.
-   * @returns {Collector} A new Collector instance.
-   *
-   * @example
-   * const qrynClient = new QrynClient({
-   *   // ... qrynClient configuration
-   * });
-   *
-   * const collector = qrynClient.createCollector({
-   *   maxBulkSize: 500,
-   *   maxTimeout: 3000
-   * });
-   */
-  createCollector(config){
-    return new Collector(this, config);
-  }
-
-  /**
-   * Create a new Stream instance.
-   * @param {Object} labels - The labels for the stream.
-   * @returns {Stream} A new Stream instance.
-   */
-  createStream(labels) {
-    return new Stream(labels);
-  }
-
-  /**
-   * Create a new Metric instance.
-   * @param {string} name - The name of the metric.
-   * @param {Object} [labels={}] - Optional labels for the metric.
-   * @returns {Metric} A new Metric instance.
-   */
-  createMetric({ name, labels = {} }) {
-    return new Metric(name, labels);
-  }
-
-  // Add more methods for other qryn operations as needed
+  createCollector(config) { return new Collector(this, config); }
+  createStream(labels)    { return new Stream(labels); }
+  createMetric({ name, labels = {} }) { return new Metric(name, labels); }
 }
 
-module.exports = { QrynClient, Stream, Metric, Collector };
+module.exports = {
+  QrynClient,
+  Stream,
+  Metric,
+  Collector,
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError
+};

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { QrynError } = require('../types');
+
+/**
+ * @typedef {Object} BasicAuth
+ * @property {'basic'} type
+ * @property {string} username
+ * @property {string} password
+ *
+ * @typedef {Object} BearerAuth
+ * @property {'bearer'} type
+ * @property {string|(() => Promise<string>)} token
+ *
+ * @typedef {Object} CustomAuth
+ * @property {'custom'} type
+ * @property {Record<string,string>|(() => Promise<Record<string,string>>)} headers
+ *
+ * @typedef {BasicAuth|BearerAuth|CustomAuth} QrynAuth
+ */
+
+/**
+ * Resolve the auth `QrynAuth` config to a header map for the next request.
+ * Bearer/custom thunks are awaited each call so the caller can refresh.
+ *
+ * @param {QrynAuth|undefined} auth
+ * @returns {Promise<Record<string,string>>}
+ */
+async function resolveAuthHeaders(auth) {
+  if (!auth) return {};
+  switch (auth.type) {
+    case 'basic': {
+      const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      return { Authorization: `Basic ${encoded}` };
+    }
+    case 'bearer': {
+      const token = typeof auth.token === 'function' ? await auth.token() : auth.token;
+      return { Authorization: `Bearer ${token}` };
+    }
+    case 'custom': {
+      const h = typeof auth.headers === 'function' ? await auth.headers() : auth.headers;
+      return { ...h };
+    }
+    default:
+      throw new QrynError(`Unsupported auth type: ${auth.type}`);
+  }
+}
+
+/**
+ * Normalize a constructor-time `auth` value: detect the legacy
+ * `{ username, password }` shape and coerce to `{ type: 'basic', ... }`.
+ *
+ * @param {QrynAuth|{username:string,password:string}|undefined} auth
+ * @returns {{ auth: QrynAuth|undefined, legacy: boolean }}
+ */
+function normalizeAuth(auth) {
+  if (!auth) return { auth: undefined, legacy: false };
+  if (!auth.type && auth.username !== undefined) {
+    return {
+      auth: { type: 'basic', username: auth.username, password: auth.password },
+      legacy: true
+    };
+  }
+  if (!['basic', 'bearer', 'custom'].includes(auth.type)) {
+    throw new QrynError(`Unsupported auth type: ${auth.type}`);
+  }
+  return { auth, legacy: false };
+}
+
+module.exports = { resolveAuthHeaders, normalizeAuth };

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -9,6 +9,13 @@ const {
 } = require('../types');
 const { resolveAuthHeaders } = require('./auth');
 const { anySignal } = require('../utils/abort');
+const {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+} = require('../utils/retry');
 
 /**
  * Handles HTTP requests for QrynClient.
@@ -34,35 +41,62 @@ class Http {
     this.fetchImpl = fetchImpl;
   }
 
-  /**
-   * @param {string} path
-   * @param {Object} [options]
-   * @param {string} [options.method]
-   * @param {Object} [options.headers]
-   * @param {*} [options.body]
-   * @param {AbortSignal} [options.signal]
-   * @param {number} [options.timeoutMs]
-   * @param {string} [options.orgId]
-   * @returns {Promise<QrynResponse>}
-   */
   async request(path, options = {}) {
+    const retryOpts = { ...DEFAULT_RETRY, ...this.defaultRetry, ...options.retry };
+    const attempts = Math.max(1, retryOpts.attempts);
+
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      if (options.signal && options.signal.aborted) {
+        throw new QrynAbortedError('Request aborted by caller', options.signal.reason, path);
+      }
+      try {
+        return await this.#singleRequest(path, options);
+      } catch (error) {
+        lastError = error;
+
+        // Caller abort: never retry.
+        if (error instanceof QrynAbortedError) throw error;
+
+        const isLast = attempt === attempts;
+        if (isLast) throw error;
+
+        let delayMs;
+        if (error instanceof QrynError && typeof error.statusCode === 'number') {
+          const retryAfterFromCustom = retryOpts.retryOn
+            ? retryOpts.retryOn(error.statusCode, attempt)
+            : isRetryableStatus(error.statusCode);
+          if (!retryAfterFromCustom) throw error;
+
+          const headerVal = error.cause && error.cause.headers
+            ? error.cause.headers.get && error.cause.headers.get('retry-after')
+            : null;
+          const fromHeader = error.statusCode === 429 ? parseRetryAfter(headerVal) : null;
+          delayMs = fromHeader != null ? fromHeader : computeBackoff(attempt, retryOpts);
+        } else if (isRetryableNetworkError(error) || (error instanceof QrynError && error.cause && isRetryableNetworkError(error.cause))) {
+          delayMs = computeBackoff(attempt, retryOpts);
+        } else {
+          throw error;
+        }
+
+        await this.#sleep(delayMs, options.signal);
+      }
+    }
+    throw lastError;
+  }
+
+  async #singleRequest(path, options) {
     const url = new URL(path, this.baseUrl);
     const effectiveTimeout = options.timeoutMs ?? this.timeout;
 
     const authHeaders = await resolveAuthHeaders(this.auth);
     const orgId = options.orgId ?? this.defaultOrgId;
 
-    const headers = {
-      ...this.headers,
-      ...options.headers,
-      ...authHeaders
-    };
+    const headers = { ...this.headers, ...options.headers, ...authHeaders };
     if (orgId) headers['X-Scope-OrgID'] = orgId;
 
     const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
-    const signal = options.signal
-      ? anySignal([options.signal, timeoutSignal])
-      : timeoutSignal;
+    const signal = options.signal ? anySignal([options.signal, timeoutSignal]) : timeoutSignal;
 
     const startedAt = Date.now();
     let response;
@@ -76,11 +110,7 @@ class Http {
     } catch (error) {
       if (error && error.name === 'AbortError') {
         if (options.signal && options.signal.aborted) {
-          throw new QrynAbortedError(
-            'Request aborted by caller',
-            options.signal.reason,
-            path
-          );
+          throw new QrynAbortedError('Request aborted by caller', options.signal.reason, path);
         }
         throw new QrynTimeoutError(
           `Request timed out after ${effectiveTimeout}ms`,
@@ -108,10 +138,25 @@ class Http {
     }
 
     if (!response.ok) {
-      throw new QrynError(`HTTP error! status: ${response.status}`, response.status, body, path);
+      const cause = { headers: response.headers, body };
+      throw new QrynError(`HTTP error! status: ${response.status}`, response.status, cause, path);
     }
 
     return new QrynResponse(body, response.status, response.headers, path);
+  }
+
+  #sleep(ms, signal) {
+    return new Promise((resolve, reject) => {
+      if (ms <= 0) return resolve();
+      const timer = setTimeout(resolve, ms);
+      if (signal) {
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(new QrynAbortedError('Request aborted by caller', signal.reason));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    });
   }
 }
 

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -21,7 +21,7 @@ class Http {
     this.baseUrl = new URL(baseUrl);
     this.timeout = timeout;
     this.headers = headers;
-    this.#setBasicAuth(auth)
+    if (auth) this.#setBasicAuth(auth)
   }
 
   /**

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -1,88 +1,117 @@
-const { QrynError } = require('../types');
+'use strict';
+
 const { URL } = require('url');
-const QrynResponse = require('../types/qrynResponse');
+const {
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
+  QrynResponse
+} = require('../types');
+const { resolveAuthHeaders } = require('./auth');
+const { anySignal } = require('../utils/abort');
 
 /**
  * Handles HTTP requests for QrynClient.
  */
 class Http {
-  baseUrl = null;
-  timeout = null;
-  headers = null;
-  basicAuth = null;
-
   /**
-   * Create an HttpClient.
-   * @param {string} baseUrl - The base URL for the qryn server.
-   * @param {number} timeout - The timeout for requests in milliseconds.
-   * @param {Object} headers - Headers to send with requests.
+   * @param {string} baseUrl
+   * @param {number} timeout - default per-request timeout in ms.
+   * @param {Object} headers - default headers, merged before auth.
+   * @param {import('./auth').QrynAuth|undefined} auth
+   * @param {Object} [opts]
+   * @param {import('../utils/retry').RetryOptions} [opts.retry]
+   * @param {string} [opts.defaultOrgId]
+   * @param {typeof globalThis.fetch} [fetchImpl] - injected for testing.
    */
-  constructor(baseUrl, timeout, headers, auth) {
+  constructor(baseUrl, timeout, headers, auth, opts = {}, fetchImpl = globalThis.fetch) {
     this.baseUrl = new URL(baseUrl);
     this.timeout = timeout;
     this.headers = headers;
-    if (auth) this.#setBasicAuth(auth)
+    this.auth = auth;
+    this.defaultRetry = opts.retry;
+    this.defaultOrgId = opts.defaultOrgId;
+    this.fetchImpl = fetchImpl;
   }
 
   /**
-   * Set basic authentication credentials.
-   * @param {string} username - The username for basic auth.
-   * @param {string} password - The password for basic auth.
-   */
-  #setBasicAuth({username, password}) {
-    this.basicAuth = Buffer.from(`${username}:${password}`).toString('base64');
-  }
-
-  /**
-   * Make an HTTP request.
-   * @param {string} path - The path to append to the base URL.
-   * @param {Object} options - The options for the fetch request.
-   * @returns {Promise<Object>} The parsed JSON response.
-   * @throws {QrynError} If the request fails or returns a non-OK status.
+   * @param {string} path
+   * @param {Object} [options]
+   * @param {string} [options.method]
+   * @param {Object} [options.headers]
+   * @param {*} [options.body]
+   * @param {AbortSignal} [options.signal]
+   * @param {number} [options.timeoutMs]
+   * @param {string} [options.orgId]
+   * @returns {Promise<QrynResponse>}
    */
   async request(path, options = {}) {
     const url = new URL(path, this.baseUrl);
-    const headers = { ...this.headers, ...options.headers };
-    let res = {};
+    const effectiveTimeout = options.timeoutMs ?? this.timeout;
 
-    // Add Authorization header if basic auth is set
-    if (this.basicAuth) {
-      headers['Authorization'] = `Basic ${this.basicAuth}`;
-    }
+    const authHeaders = await resolveAuthHeaders(this.auth);
+    const orgId = options.orgId ?? this.defaultOrgId;
 
-    const fetchOptions = {
-      ...options,
-      headers,
-      signal: AbortSignal.timeout(this.timeout)
+    const headers = {
+      ...this.headers,
+      ...options.headers,
+      ...authHeaders
     };
+    if (orgId) headers['X-Scope-OrgID'] = orgId;
 
+    const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
+    const signal = options.signal
+      ? anySignal([options.signal, timeoutSignal])
+      : timeoutSignal;
+
+    const startedAt = Date.now();
+    let response;
     try {
-      const response = await fetch(url.toString(), fetchOptions);
-
-      // Parse the body based on the response Content-Type, not the request's.
-      // Empty bodies (204, no content-length) are tolerated.
-      const responseContentType = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
-      if (response.status !== 204) {
-        if (responseContentType.includes('application/json')) {
-          res = await response.json().catch(() => ({}));
-        } else if (responseContentType) {
-          const text = await response.text().catch(() => '');
-          res = text || {};
-        }
-      }
-
-      if (!response.ok) {
-        let message = `HTTP error! status: ${response.status}`
-        throw new QrynError(message, response.status, res, path);
-      }
-
-      return new QrynResponse(res, response.status, response.headers, path)
-
+      response = await this.fetchImpl(url.toString(), {
+        method: options.method,
+        headers,
+        body: options.body,
+        signal
+      });
     } catch (error) {
-      if(error instanceof QrynError)
-        throw error;
-      throw new QrynError(`Request failed: ${error.message} ${error?.cause?.message ?? ''}`.trim(), 400, error.cause, path);
+      if (error && error.name === 'AbortError') {
+        if (options.signal && options.signal.aborted) {
+          throw new QrynAbortedError(
+            'Request aborted by caller',
+            options.signal.reason,
+            path
+          );
+        }
+        throw new QrynTimeoutError(
+          `Request timed out after ${effectiveTimeout}ms`,
+          Date.now() - startedAt,
+          path
+        );
+      }
+      throw new QrynError(
+        `Request failed: ${error.message} ${error?.cause?.message ?? ''}`.trim(),
+        400,
+        error.cause,
+        path
+      );
     }
+
+    let body = {};
+    const ct = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+    if (response.status !== 204) {
+      if (ct.includes('application/json')) {
+        body = await response.json().catch(() => ({}));
+      } else if (ct) {
+        const text = await response.text().catch(() => '');
+        body = text || {};
+      }
+    }
+
+    if (!response.ok) {
+      throw new QrynError(`HTTP error! status: ${response.status}`, response.status, body, path);
+    }
+
+    return new QrynResponse(body, response.status, response.headers, path);
   }
 }
 

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -59,22 +59,29 @@ class Http {
     try {
       const response = await fetch(url.toString(), fetchOptions);
 
-
-      if(headers['Content-Type'] === 'application/x-www-form-urlencoded'){
-        res = await response.json();
+      // Parse the body based on the response Content-Type, not the request's.
+      // Empty bodies (204, no content-length) are tolerated.
+      const responseContentType = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+      if (response.status !== 204) {
+        if (responseContentType.includes('application/json')) {
+          res = await response.json().catch(() => ({}));
+        } else if (responseContentType) {
+          const text = await response.text().catch(() => '');
+          res = text || {};
+        }
       }
 
       if (!response.ok) {
         let message = `HTTP error! status: ${response.status}`
         throw new QrynError(message, response.status, res, path);
       }
-      
+
       return new QrynResponse(res, response.status, response.headers, path)
-      
+
     } catch (error) {
       if(error instanceof QrynError)
         throw error;
-      throw new QrynError(`Request failed: ${error.message} ${error?.cause?.message}`, 400, error.cause, path);    
+      throw new QrynError(`Request failed: ${error.message} ${error?.cause?.message ?? ''}`.trim(), 400, error.cause, path);
     }
   }
 }

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -148,9 +148,13 @@ class Http {
   #sleep(ms, signal) {
     return new Promise((resolve, reject) => {
       if (ms <= 0) return resolve();
-      const timer = setTimeout(resolve, ms);
+      let onAbort;
+      const timer = setTimeout(() => {
+        if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
       if (signal) {
-        const onAbort = () => {
+        onAbort = () => {
           clearTimeout(timer);
           reject(new QrynAbortedError('Request aborted by caller', signal.reason));
         };

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,5 +1,7 @@
-const QrynError = require("./qrynError");
-const QrynResponse = require("./qrynResponse");
+const QrynError = require('./qrynError');
+const QrynResponse = require('./qrynResponse');
+const QrynAbortedError = require('./qrynAbortedError');
+const QrynTimeoutError = require('./qrynTimeoutError');
 
 class NetworkError extends QrynError {
   constructor(message, options = {}) {
@@ -21,5 +23,7 @@ module.exports = {
   NetworkError,
   ValidationError,
   QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
   QrynResponse
-}
+};

--- a/src/types/qrynAbortedError.js
+++ b/src/types/qrynAbortedError.js
@@ -1,0 +1,21 @@
+const QrynError = require('./qrynError');
+
+/**
+ * Thrown when a request is aborted by a caller-supplied AbortSignal.
+ * Distinct from QrynTimeoutError (which signals the request's own timeout fired)
+ * and from network errors.
+ */
+class QrynAbortedError extends QrynError {
+  /**
+   * @param {string} message
+   * @param {*} [reason] - The AbortSignal.reason at abort time, if any.
+   * @param {string} [path]
+   */
+  constructor(message, reason, path) {
+    super(message, null, reason, path);
+    this.name = 'QrynAbortedError';
+    this.reason = reason;
+  }
+}
+
+module.exports = QrynAbortedError;

--- a/src/types/qrynResponse.js
+++ b/src/types/qrynResponse.js
@@ -26,10 +26,10 @@ class QrynResponse {
 
   /**
    * Get the response data.
-   * @returns {Object} The response data.
+   * @returns {Object} The response body.
    */
   getData() {
-    return this.data;
+    return this.response;
   }
 
   /**
@@ -67,7 +67,7 @@ class QrynResponse {
    * @returns {string} A string representation of the response.
    */
   toString() {
-    return this.type + ` Response {status: ${this.status}, data: ${JSON.stringify(this.data)}}`;
+    return `QrynResponse {status: ${this.status}, path: ${this.path}, data: ${JSON.stringify(this.response)}}`;
   }
 }
 

--- a/src/types/qrynTimeoutError.js
+++ b/src/types/qrynTimeoutError.js
@@ -1,0 +1,21 @@
+const QrynError = require('./qrynError');
+
+/**
+ * Thrown when the per-request timeout (timeoutMs) elapses before the
+ * fetch resolves. Distinct from QrynAbortedError (caller-driven) and
+ * from network errors.
+ */
+class QrynTimeoutError extends QrynError {
+  /**
+   * @param {string} message
+   * @param {number} elapsedMs
+   * @param {string} [path]
+   */
+  constructor(message, elapsedMs, path) {
+    super(message, null, undefined, path);
+    this.name = 'QrynTimeoutError';
+    this.elapsedMs = elapsedMs;
+  }
+}
+
+module.exports = QrynTimeoutError;

--- a/src/utils/abort.js
+++ b/src/utils/abort.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Returns an AbortSignal that aborts when ANY of the input signals abort.
+ * Wraps `AbortSignal.any` when available (Node 20+); otherwise registers
+ * one-shot listeners on each input signal.
+ *
+ * Null/undefined inputs are silently dropped.
+ *
+ * @param {Array<AbortSignal|null|undefined>} signals
+ * @returns {AbortSignal}
+ */
+function anySignal(signals) {
+  const inputs = signals.filter(s => s != null);
+
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(inputs);
+  }
+
+  const controller = new AbortController();
+
+  // Already aborted? Forward immediately.
+  for (const s of inputs) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+  }
+
+  const onAbort = (event) => {
+    const source = event.target;
+    controller.abort(source.reason);
+    for (const s of inputs) {
+      s.removeEventListener('abort', onAbort);
+    }
+  };
+
+  for (const s of inputs) {
+    s.addEventListener('abort', onAbort, { once: true });
+  }
+
+  return controller.signal;
+}
+
+module.exports = { anySignal };

--- a/src/utils/retry.js
+++ b/src/utils/retry.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const DEFAULT_RETRY = Object.freeze({
+  attempts: 3,
+  baseDelayMs: 200,
+  maxDelayMs: 5000
+});
+
+const RETRYABLE_STATUS = new Set([408, 429, 502, 503, 504]);
+const RETRYABLE_NET_CODES = new Set(['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN']);
+
+/**
+ * Exponential backoff with full jitter.
+ * delay = jitter * min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1))
+ *
+ * @param {number} attempt - 1-based attempt number that just failed.
+ * @param {{ baseDelayMs: number, maxDelayMs: number }} opts
+ * @param {() => number} [random=Math.random] - Injected for testing.
+ * @returns {number} delay in milliseconds before the next attempt.
+ */
+function computeBackoff(attempt, opts, random = Math.random) {
+  const exp = opts.baseDelayMs * Math.pow(2, attempt - 1);
+  const capped = Math.min(opts.maxDelayMs, exp);
+  return Math.floor(random() * capped);
+}
+
+/**
+ * Parse a Retry-After header (RFC 7231).
+ * @param {string|null|undefined} value
+ * @returns {number|null} milliseconds to wait, or null if unparseable.
+ */
+function parseRetryAfter(value) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (trimmed === '') return null;
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  const ts = Date.parse(trimmed);
+  if (Number.isNaN(ts)) return null;
+  return Math.max(0, ts - Date.now());
+}
+
+/**
+ * @param {number} status
+ * @returns {boolean}
+ */
+function isRetryableStatus(status) {
+  return RETRYABLE_STATUS.has(status);
+}
+
+/**
+ * @param {{code?: string, cause?: {code?: string}} | null | undefined} err
+ * @returns {boolean}
+ */
+function isRetryableNetworkError(err) {
+  if (!err) return false;
+  if (err.code && RETRYABLE_NET_CODES.has(err.code)) return true;
+  if (err.cause && err.cause.code && RETRYABLE_NET_CODES.has(err.cause.code)) return true;
+  return false;
+}
+
+module.exports = {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+};

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { QrynError } = require('../types');
+
+/**
+ * Normalize a time input to a nanosecond integer string.
+ * - Date          → milliseconds × 1e6
+ * - number < 1e12 → assumed seconds, multiplied to ns
+ * - number < 1e15 → assumed milliseconds, multiplied to ns
+ * - number ≥ 1e15 → assumed nanoseconds (kept)
+ * - string        → returned unchanged (caller knows the unit)
+ *
+ * Returned as a string to preserve precision beyond Number.MAX_SAFE_INTEGER.
+ *
+ * @param {Date|number|string} input
+ * @returns {string}
+ */
+function toNanos(input) {
+  if (input == null) {
+    throw new QrynError('toNanos: input is required');
+  }
+  if (input instanceof Date) {
+    return (BigInt(input.getTime()) * 1000000n).toString();
+  }
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    if (input < 1e12) {
+      return (BigInt(Math.trunc(input)) * 1000000000n).toString();
+    }
+    if (input < 1e15) {
+      return (BigInt(Math.trunc(input)) * 1000000n).toString();
+    }
+    return BigInt(Math.trunc(input)).toString();
+  }
+  throw new QrynError(`toNanos: unsupported input type ${typeof input}`);
+}
+
+module.exports = { toNanos };

--- a/tests/types/consumer-smoke.ts
+++ b/tests/types/consumer-smoke.ts
@@ -1,0 +1,88 @@
+import {
+  QrynClient,
+  QrynError,
+  QrynAbortedError,
+  QrynTimeoutError,
+  type QrynAuth,
+  type RetryOptions,
+  type ReadOpts,
+  type SearchOpts,
+} from 'qryn-client';
+
+// 1. Constructor with each auth shape.
+const basic = new QrynClient({
+  baseUrl: 'http://localhost:3100',
+  auth: { type: 'basic', username: 'u', password: 'p' },
+});
+
+const bearer = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { type: 'bearer', token: async () => 'tok' },
+});
+
+const custom = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { type: 'custom', headers: { 'X-Api-Key': 'k' } },
+});
+
+// 2. Legacy shape still compiles (deprecated at runtime).
+const legacy = new QrynClient({
+  baseUrl: 'http://x',
+  auth: { username: 'u', password: 'p' },
+});
+
+// 3. RetryOptions + defaultOrgId.
+const retry: RetryOptions = { attempts: 3, baseDelayMs: 200, maxDelayMs: 5000 };
+const withRetry = new QrynClient({
+  baseUrl: 'http://x',
+  retry,
+  defaultOrgId: 'tenant-a',
+});
+
+// 4. Loki reader.
+async function lokiSmoke() {
+  const reader = basic.loki.createReader({ orgId: 'tenant-a' });
+  const opts: ReadOpts = { timeoutMs: 30_000, retry };
+  const inst = await reader.query('{job="x"}', new Date(), opts);
+  inst.response.data.resultType;
+
+  const range = await reader.queryRange(
+    '{job="x"}',
+    new Date(Date.now() - 3600_000),
+    new Date(),
+    '15s',
+    100,
+    'backward',
+    opts
+  );
+  range.response.data.result;
+
+  const labels = await reader.labels(undefined, undefined, opts);
+  labels.response.data;
+
+  await reader.labelValues('job', undefined, undefined, undefined, opts);
+  await reader.series(['{a="1"}'], undefined, undefined, opts);
+}
+
+// 5. Tempo.
+async function tempoSmoke() {
+  const t = basic.tempo;
+  const search: SearchOpts = { q: '{ duration > 1s }', limit: 5 };
+  await t.search(search, { signal: new AbortController().signal });
+  await t.searchTags('span');
+  await t.searchTagValues('service.name');
+  await t.getTrace('abc');
+}
+
+// 6. Errors are catchable as classes.
+async function errorSmoke() {
+  try {
+    await basic.tempo.search({ q: 'x' });
+  } catch (e) {
+    if (e instanceof QrynAbortedError) e.reason;
+    if (e instanceof QrynTimeoutError) e.elapsedMs;
+    if (e instanceof QrynError) e.statusCode;
+  }
+}
+
+void [basic, bearer, custom, legacy, withRetry, lokiSmoke, tempoSmoke, errorSmoke];

--- a/tests/unit/abort.test.js
+++ b/tests/unit/abort.test.js
@@ -1,0 +1,43 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { anySignal } = require('../../src/utils/abort');
+
+test('returns a signal already aborted when an input is already aborted', () => {
+  const a = new AbortController();
+  a.abort('first');
+  const signal = anySignal([a.signal, new AbortController().signal]);
+  assert.equal(signal.aborted, true);
+});
+
+test('aborts when the first input aborts', () => {
+  const a = new AbortController();
+  const b = new AbortController();
+  const signal = anySignal([a.signal, b.signal]);
+  assert.equal(signal.aborted, false);
+  a.abort('boom');
+  assert.equal(signal.aborted, true);
+});
+
+test('aborts when the second input aborts', () => {
+  const a = new AbortController();
+  const b = new AbortController();
+  const signal = anySignal([a.signal, b.signal]);
+  b.abort('boom2');
+  assert.equal(signal.aborted, true);
+});
+
+test('passes the original reason through', () => {
+  const a = new AbortController();
+  const reason = new Error('caller abort');
+  const signal = anySignal([a.signal]);
+  a.abort(reason);
+  assert.equal(signal.reason, reason);
+});
+
+test('drops null/undefined signals', () => {
+  const a = new AbortController();
+  const signal = anySignal([null, undefined, a.signal]);
+  assert.equal(signal.aborted, false);
+  a.abort();
+  assert.equal(signal.aborted, true);
+});

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -1,0 +1,67 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveAuthHeaders, normalizeAuth } = require('../../src/services/auth');
+
+test('basic: builds Authorization header', async () => {
+  const headers = await resolveAuthHeaders({ type: 'basic', username: 'u', password: 'p' });
+  const expected = 'Basic ' + Buffer.from('u:p').toString('base64');
+  assert.equal(headers.Authorization, expected);
+});
+
+test('bearer: string token', async () => {
+  const headers = await resolveAuthHeaders({ type: 'bearer', token: 'abc' });
+  assert.equal(headers.Authorization, 'Bearer abc');
+});
+
+test('bearer: thunk is awaited each call', async () => {
+  let n = 0;
+  const tokenFn = async () => `token-${++n}`;
+  const a = await resolveAuthHeaders({ type: 'bearer', token: tokenFn });
+  const b = await resolveAuthHeaders({ type: 'bearer', token: tokenFn });
+  assert.equal(a.Authorization, 'Bearer token-1');
+  assert.equal(b.Authorization, 'Bearer token-2');
+});
+
+test('custom: object headers', async () => {
+  const headers = await resolveAuthHeaders({
+    type: 'custom',
+    headers: { 'X-Api-Key': 'abc' }
+  });
+  assert.deepEqual(headers, { 'X-Api-Key': 'abc' });
+});
+
+test('custom: thunk headers', async () => {
+  const headers = await resolveAuthHeaders({
+    type: 'custom',
+    headers: async () => ({ 'X-Api-Key': 'fresh' })
+  });
+  assert.deepEqual(headers, { 'X-Api-Key': 'fresh' });
+});
+
+test('undefined auth → empty headers', async () => {
+  const headers = await resolveAuthHeaders(undefined);
+  assert.deepEqual(headers, {});
+});
+
+test('normalizeAuth: legacy {username,password} coerced to basic', () => {
+  const result = normalizeAuth({ username: 'u', password: 'p' });
+  assert.equal(result.legacy, true);
+  assert.deepEqual(result.auth, { type: 'basic', username: 'u', password: 'p' });
+});
+
+test('normalizeAuth: typed auth passes through', () => {
+  const a = { type: 'bearer', token: 't' };
+  const result = normalizeAuth(a);
+  assert.equal(result.legacy, false);
+  assert.equal(result.auth, a);
+});
+
+test('normalizeAuth: undefined passes through', () => {
+  const result = normalizeAuth(undefined);
+  assert.equal(result.legacy, false);
+  assert.equal(result.auth, undefined);
+});
+
+test('normalizeAuth: unknown type rejected', () => {
+  assert.throws(() => normalizeAuth({ type: 'banana' }));
+});

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -1,0 +1,99 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+const { QrynError, QrynAbortedError, QrynTimeoutError } = require('../../src/types');
+
+function mockFetch(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    return impl(url, init);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function jsonOk(body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...headers }
+  });
+}
+
+test('basic auth header is set', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({ ok: true }));
+  const http = new Http('http://q', 60000, {}, { type: 'basic', username: 'u', password: 'p' }, {}, fetchSpy);
+  await http.request('/health');
+  const auth = fetchSpy.calls[0].init.headers.Authorization;
+  assert.equal(auth, 'Basic ' + Buffer.from('u:p').toString('base64'));
+});
+
+test('bearer thunk auth header is awaited', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, { type: 'bearer', token: async () => 'fresh' }, {}, fetchSpy);
+  await http.request('/health');
+  assert.equal(fetchSpy.calls[0].init.headers.Authorization, 'Bearer fresh');
+});
+
+test('defaultOrgId becomes X-Scope-OrgID', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, undefined, { defaultOrgId: 'tenant-a' }, fetchSpy);
+  await http.request('/health');
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-a');
+});
+
+test('per-call orgId overrides defaultOrgId', async () => {
+  const fetchSpy = mockFetch(() => jsonOk({}));
+  const http = new Http('http://q', 60000, {}, undefined, { defaultOrgId: 'tenant-a' }, fetchSpy);
+  await http.request('/health', { orgId: 'tenant-b' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-b');
+});
+
+test('per-call timeoutMs maps an AbortError to QrynTimeoutError', async () => {
+  const fetchSpy = mockFetch(async (_url, init) => {
+    await new Promise((resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      }, { once: true });
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  await assert.rejects(
+    () => http.request('/slow', { timeoutMs: 5 }),
+    (err) => err instanceof QrynTimeoutError && typeof err.elapsedMs === 'number'
+  );
+});
+
+test('caller AbortSignal maps to QrynAbortedError', async () => {
+  const fetchSpy = mockFetch(async (_url, init) => {
+    await new Promise((resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      }, { once: true });
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  const ac = new AbortController();
+  const reason = new Error('user-cancel');
+  setTimeout(() => ac.abort(reason), 5);
+  await assert.rejects(
+    () => http.request('/slow', { signal: ac.signal, timeoutMs: 60000 }),
+    (err) => err instanceof QrynAbortedError && err.reason === reason
+  );
+});
+
+test('non-2xx still throws QrynError', async () => {
+  const fetchSpy = mockFetch(() => new Response(JSON.stringify({ msg: 'bad' }), {
+    status: 400,
+    headers: { 'content-type': 'application/json' }
+  }));
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  await assert.rejects(
+    () => http.request('/x'),
+    (err) => err instanceof QrynError && err.statusCode === 400
+  );
+});

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -97,3 +97,80 @@ test('non-2xx still throws QrynError', async () => {
     (err) => err instanceof QrynError && err.statusCode === 400
   );
 });
+
+test('retry: 503 retried up to attempts then fails', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    return new Response('boom', { status: 503 });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await assert.rejects(() => http.request('/x'));
+  assert.equal(calls, 3);
+});
+
+test('retry: 200 returns immediately, no extra calls', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => { calls++; return jsonOk({ ok: true }); });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await http.request('/x');
+  assert.equal(calls, 1);
+});
+
+test('retry: 400 not retried', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    return new Response(JSON.stringify({ err: 'bad' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 1, maxDelayMs: 1 }
+  }, fetchSpy);
+  await assert.rejects(() => http.request('/x'));
+  assert.equal(calls, 1);
+});
+
+test('retry: 429 honors Retry-After header', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(() => {
+    calls++;
+    if (calls === 1) {
+      return new Response('limit', { status: 429, headers: { 'Retry-After': '0' } });
+    }
+    return jsonOk({ ok: true });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 3, baseDelayMs: 5000, maxDelayMs: 5000 }
+  }, fetchSpy);
+  const t0 = Date.now();
+  await http.request('/x');
+  const elapsed = Date.now() - t0;
+  // baseDelayMs=5000 would force a long wait; Retry-After:0 must short-circuit it.
+  assert.ok(elapsed < 1000, `expected <1s, got ${elapsed}ms`);
+  assert.equal(calls, 2);
+});
+
+test('retry: caller-aborted signal stops the loop', async () => {
+  let calls = 0;
+  const fetchSpy = mockFetch(async (_url, init) => {
+    calls++;
+    return new Response('boom', { status: 503 });
+  });
+  const http = new Http('http://q', 60000, {}, undefined, {
+    retry: { attempts: 5, baseDelayMs: 50, maxDelayMs: 50 }
+  }, fetchSpy);
+  const ac = new AbortController();
+  setTimeout(() => ac.abort(new Error('cancel')), 20);
+  await assert.rejects(
+    () => http.request('/x', { signal: ac.signal }),
+    (err) => err instanceof QrynAbortedError
+  );
+  assert.ok(calls < 5, `expected loop to short-circuit, got ${calls} calls`);
+});

--- a/tests/unit/loki-push.test.js
+++ b/tests/unit/loki-push.test.js
@@ -1,0 +1,30 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+const Loki = require('../../src/clients/loki');
+const Stream = require('../../src/models/stream');
+
+function mockFetch() {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response('', { status: 200 });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeStream() {
+  const s = new Stream({ app: 'x' });
+  s.addEntry(Date.now(), 'msg');
+  return s;
+}
+
+test('Loki.push: per-call orgId overrides defaultOrgId', async () => {
+  const fetchSpy = mockFetch();
+  const http = new Http('http://q', 60000, {}, undefined, { defaultOrgId: 'A' }, fetchSpy);
+  const loki = new Loki(http);
+  const s = makeStream();
+  await loki.push([s], { orgId: 'B' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'B');
+});

--- a/tests/unit/loki-read.test.js
+++ b/tests/unit/loki-read.test.js
@@ -1,0 +1,84 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+
+function jsonOk(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+function fetchCapture(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return impl ? impl(url, init) : jsonOk({ status: 'success', data: {} });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeClient(fetchSpy) {
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  const Loki = require('../../src/clients/loki');
+  return new Loki(http).createReader({ orgId: 'tenant-a' });
+}
+
+test('query: GET /loki/api/v1/query with normalized time', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.query('{job="x"} |= `boom`', new Date(1700000000000));
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /\/loki\/api\/v1\/query\?/);
+  assert.match(call.url, /query=%7Bjob%3D%22x%22%7D/);
+  assert.match(call.url, /time=1700000000000000000/);
+  assert.equal(call.init.method, 'GET');
+  assert.equal(call.init.headers['X-Scope-OrgID'], 'tenant-a');
+});
+
+test('queryRange: passes step, limit, direction', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.queryRange('{job="x"}', 1700000000, 1700003600, '15s', 100, 'backward');
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /step=15s/);
+  assert.match(call.url, /limit=100/);
+  assert.match(call.url, /direction=backward/);
+  assert.match(call.url, /start=1700000000000000000/);
+  assert.match(call.url, /end=1700003600000000000/);
+});
+
+test('labels: omits start/end when not given', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labels();
+  const call = fetchSpy.calls[0];
+  assert.match(call.url, /\/loki\/api\/v1\/labels(\?|$)/);
+  assert.doesNotMatch(call.url, /start=/);
+  assert.doesNotMatch(call.url, /end=/);
+});
+
+test('labelValues: encodes label name', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labelValues('job');
+  assert.match(fetchSpy.calls[0].url, /\/loki\/api\/v1\/label\/job\/values/);
+});
+
+test('series: repeated match[] params', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.series(['{a="1"}', '{b="2"}'], 1700000000, 1700003600);
+  const call = fetchSpy.calls[0];
+  // URLSearchParams encodes both as repeated match%5B%5D=
+  assert.match(call.url, /match%5B%5D=%7Ba%3D%221%22%7D/);
+  assert.match(call.url, /match%5B%5D=%7Bb%3D%222%22%7D/);
+});
+
+test('per-call opts.orgId overrides reader-level orgId', async () => {
+  const fetchSpy = fetchCapture();
+  const reader = makeClient(fetchSpy);
+  await reader.labels(undefined, undefined, { orgId: 'tenant-b' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-b');
+});

--- a/tests/unit/retry.test.js
+++ b/tests/unit/retry.test.js
@@ -1,0 +1,64 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  DEFAULT_RETRY,
+  computeBackoff,
+  parseRetryAfter,
+  isRetryableStatus,
+  isRetryableNetworkError
+} = require('../../src/utils/retry');
+
+test('DEFAULT_RETRY matches spec defaults', () => {
+  assert.equal(DEFAULT_RETRY.attempts, 3);
+  assert.equal(DEFAULT_RETRY.baseDelayMs, 200);
+  assert.equal(DEFAULT_RETRY.maxDelayMs, 5000);
+});
+
+test('computeBackoff: exponential growth, capped at maxDelayMs', (t) => {
+  // Force jitter to identity for assertable math.
+  const random = () => 1.0;
+  assert.equal(computeBackoff(1, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 200);
+  assert.equal(computeBackoff(2, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 400);
+  assert.equal(computeBackoff(3, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 800);
+  assert.equal(computeBackoff(10, { baseDelayMs: 200, maxDelayMs: 5000 }, random), 5000);
+});
+
+test('computeBackoff: jitter scales the delay by [0,1)', () => {
+  const fixed = computeBackoff(2, { baseDelayMs: 200, maxDelayMs: 5000 }, () => 0.5);
+  assert.equal(fixed, 200);
+});
+
+test('parseRetryAfter: numeric seconds', () => {
+  assert.equal(parseRetryAfter('5'), 5000);
+  assert.equal(parseRetryAfter('0'), 0);
+});
+
+test('parseRetryAfter: HTTP-date', () => {
+  const future = new Date(Date.now() + 3000);
+  const ms = parseRetryAfter(future.toUTCString());
+  assert.ok(ms >= 2000 && ms <= 4000);
+});
+
+test('parseRetryAfter: invalid → null', () => {
+  assert.equal(parseRetryAfter('garbage'), null);
+  assert.equal(parseRetryAfter(undefined), null);
+  assert.equal(parseRetryAfter(null), null);
+});
+
+test('isRetryableStatus: only 408, 429, 502, 503, 504', () => {
+  for (const s of [408, 429, 502, 503, 504]) {
+    assert.equal(isRetryableStatus(s), true, `${s} should be retryable`);
+  }
+  for (const s of [200, 400, 401, 403, 404, 422, 500, 501]) {
+    assert.equal(isRetryableStatus(s), false, `${s} must not be retryable`);
+  }
+});
+
+test('isRetryableNetworkError: known codes', () => {
+  for (const code of ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN']) {
+    assert.equal(isRetryableNetworkError({ code }), true);
+    assert.equal(isRetryableNetworkError({ cause: { code } }), true);
+  }
+  assert.equal(isRetryableNetworkError({ code: 'EPERM' }), false);
+  assert.equal(isRetryableNetworkError(null), false);
+});

--- a/tests/unit/sanity.test.js
+++ b/tests/unit/sanity.test.js
@@ -1,0 +1,6 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('runner is alive', () => {
+  assert.equal(1 + 1, 2);
+});

--- a/tests/unit/tempo.test.js
+++ b/tests/unit/tempo.test.js
@@ -1,0 +1,78 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Http = require('../../src/services/http');
+const TempoClient = require('../../src/clients/tempo');
+
+function jsonOk(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+function fetchCapture() {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return jsonOk({ traces: [] });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function client(fetchSpy) {
+  const http = new Http('http://q', 60000, {}, undefined, {}, fetchSpy);
+  return new TempoClient(http);
+}
+
+test('searchTags: scope query param', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags('span');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tags\?scope=span$/);
+});
+
+test('searchTags: scope omitted when not given', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags();
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tags(\?)?$/);
+});
+
+test('searchTagValues: v1 path encodes tag', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTagValues('service.name');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\/tag\/service\.name\/values/);
+});
+
+test('getTrace: aliases getTraceSpansJson path', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.getTrace('abc123');
+  assert.match(fetchSpy.calls[0].url, /\/api\/traces\/abc123\/json/);
+});
+
+test('search: SearchOpts object becomes query string with q', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.search({ q: '{ duration > 1s }', limit: 5, spss: 10 });
+  const url = fetchSpy.calls[0].url;
+  assert.match(url, /q=%7B\+duration\+%3E\+1s\+%7D/);
+  assert.match(url, /limit=5/);
+  assert.match(url, /spss=10/);
+});
+
+test('search: string input preserved (back-compat)', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.search('q=foo');
+  assert.match(fetchSpy.calls[0].url, /\/api\/search\?q=foo$/);
+});
+
+test('opts.orgId sets X-Scope-OrgID', async () => {
+  const fetchSpy = fetchCapture();
+  const t = client(fetchSpy);
+  await t.searchTags('span', { orgId: 'tenant-a' });
+  assert.equal(fetchSpy.calls[0].init.headers['X-Scope-OrgID'], 'tenant-a');
+});

--- a/tests/unit/time.test.js
+++ b/tests/unit/time.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { toNanos } = require('../../src/utils/time');
+
+test('Date → nanoseconds string', () => {
+  const d = new Date(1700000000000); // 2023-11-14T22:13:20Z
+  assert.equal(toNanos(d), '1700000000000000000');
+});
+
+test('seconds heuristic (number < 1e12) → nanoseconds', () => {
+  assert.equal(toNanos(1700000000), '1700000000000000000');
+});
+
+test('milliseconds heuristic (1e12 <= number < 1e15) → nanoseconds', () => {
+  assert.equal(toNanos(1700000000000), '1700000000000000000');
+});
+
+test('nanoseconds heuristic (number >= 1e15) → unchanged (string form)', () => {
+  assert.equal(toNanos(1700000000000000000), '1700000000000000000');
+});
+
+test('string passes through unchanged', () => {
+  assert.equal(toNanos('1700000000000000123'), '1700000000000000123');
+});
+
+test('throws on null/undefined', () => {
+  assert.throws(() => toNanos(null));
+  assert.throws(() => toNanos(undefined));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "qryn-client": ["./index.d.ts"]
+    }
   },
   "include": ["index.d.ts", "tests/types/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["index.d.ts", "tests/types/**/*"]
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "outDir": "dist/types",
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}


### PR DESCRIPTION
## Summary

Implements P0 + P1 of the Voicenter qryn-MCP extensions requirements as a non-breaking minor release.

- **HTTP layer.** `Http.request` now accepts per-call `signal`, `timeoutMs`, `retry`, `orgId`. Caller `AbortSignal` is combined with the per-request timeout via `AbortSignal.any` (Node-18 polyfill in `src/utils/abort.js`).
- **Retry policy.** Exponential backoff with full jitter; honors `Retry-After` on `429`; never retries `4xx` other than `408`/`429`; never retries on caller abort. Defaults: `attempts=3, baseDelayMs=200, maxDelayMs=5000`.
- **Pluggable auth.** Discriminated union `{ type: 'basic' | 'bearer' | 'custom', ... }`. Bearer/custom thunks are awaited per request. Legacy `{ username, password }` shape still accepted with a one-shot `process.emitWarning` (code `QRYN_AUTH_LEGACY`); removal targeted for `2.0.0`.
- **New `LokiReader`** (`client.loki.createReader()`) covering full LogQL surface: `query`, `queryRange`, `labels`, `labelValues`, `series`. Time inputs (`Date | number | string`) normalized to nanosecond strings via `toNanos`.
- **Tempo alignment.** New `searchTags`, `searchTagValues`, `getTrace` (alias of `getTraceSpansJson`). `search` generalized to accept a `SearchOpts` object while preserving back-compat with string / `URLSearchParams`.
- **TypeScript types.** Hand-written `index.d.ts` at the repo root + `tsc --declaration --allowJs` emit to `dist/types/`. Consumer-smoke compiles clean under `--strict`.
- **New errors.** `QrynAbortedError`, `QrynTimeoutError`. Full hierarchy (BadRequest/Server/Network) deferred to a follow-up.
- **Default `timeout`** raised from 5 s to 60 s. Override via constructor `timeout` or per-call `timeoutMs`.
- **No new runtime dependencies.** Tests via Node's built-in `node:test` (devDep on `typescript` only).
